### PR TITLE
AG: updated for status badges - using a third party badge generator

### DIFF
--- a/docs/status/index.md
+++ b/docs/status/index.md
@@ -4,9 +4,8 @@ The below represents the broad status of each service.
 
 | Service | Status | Notes |
 |:--------|:------:|:------|
-|VM SSH Gateway | UP | Beta Test, not generally available |
-|VM VDI Gateway | UP | Beta Test, not generally available |
-|VM Platform | UP | Beta Test, not generally available |
-|Cerebras CS-1 | UP | Available for use |
-|SuperDome Flex (SDF-CS1 / Ultra2) | UP | Available for use |
-
+| VM SSH Gateway  | ![Custom badge](https://img.shields.io/endpoint?style=plastic&url=https://epcced.github.io/eidf-status/Data/sshgateway.json) | Beta Test, not generally available |
+| VM VDI Gateway | ![Custom badge](https://img.shields.io/endpoint?style=plastic&url=https://epcced.github.io/eidf-status/Data/vdigateway.json) | Beta Test, not generally available |
+| VM Platform | ![Custom badge](https://img.shields.io/endpoint?style=plastic&url=https://epcced.github.io/eidf-status/Data/virtualmachines.json) | Beta Test, not generally available |
+| Cerebras CS-1 | ![Custom badge](https://img.shields.io/endpoint?style=plastic&url=https://epcced.github.io/eidf-status/Data/cerebras.json) | Available for use |
+| SuperDome Flex (SDF-CS1 / Ultra2) | ![Custom badge](https://img.shields.io/endpoint?style=plastic&url=https://epcced.github.io/eidf-status/Data/superdome.json) | Available for use |


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

EIDF Service Status badges in both colour and text formatting are controlled via a second repository until we get actual live status endpoints. the status for each service (until we get endpoints to hit for live updates) would be stored in a JSON file in a repo (served on github.io) separately from the main docs - in the docs, we have a link to the shield.io service which takes in the file from the second repo and returns the badge image for up/down. To update the status, you would update the JSON file in the second repo rather than change the actual docs 

epcced/eidf-status repository with files in Data/ for all active/proposed services having a JSON file of format:

```json
{
  "schemaVersion": 1,
  "label": "",
  "message": "Active Beta",
  "color": "green"
}
```

Files in second repo:

- cerebras.json
- sshgateway.json
- superdome.json
- vdigateway.json
- virtualmachines.json

## Type of change

- [x] Formatting


## What has to be reviewed

- File: docs/status/index.md
- Repo: epcced/eidf-status

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
