### PR TITLE
Fix link to SAFE

### DIFF
--- a/docs/services/cs2/run.md
+++ b/docs/services/cs2/run.md
@@ -6,7 +6,7 @@ The Cerebras CS-2 system is attached to the SDF-CS1 (Ultra2) system which serves
 
 ## Login
 
-To login to the host system, use the username and password you obtain from [SAFE](https://www.safe.epcc.ed.ac.uk), along with the SSH Key you registered when creating the account.
+To login to the host system, use the username and password you obtain from [SAFE](https://safe.epcc.ed.ac.uk), along with the SSH Key you registered when creating the account.
 You can then login directly to the host via: `ssh <username>@sdf-cs1.epcc.ed.ac.uk`
 
 ## Running Jobs


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

The link to SAFE does not work with `www` in it.


## Type of change

Please delete options that are not relevant.

- [x] Incorrect Documentation

## What has to be reviewed

List the pages/sections that are to be reviewed.

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
