### PR TITLE
Update L1_getting_started.md

### DIFF
--- a/docs/services/gpuservice/training/L1_getting_started.md
+++ b/docs/services/gpuservice/training/L1_getting_started.md
@@ -67,7 +67,7 @@ Finally, it optional to define GPU resources but only the `limits` tag is used t
 apiVersion: v1
 kind: Pod
 metadata:
-generateName: first-pod-
+  generateName: first-pod-
 spec:
  restartPolicy: OnFailure
  containers:

--- a/docs/services/gpuservice/training/L1_getting_started.md
+++ b/docs/services/gpuservice/training/L1_getting_started.md
@@ -11,6 +11,10 @@ Using K8s to manage the EIDFGPUS provides two key advantages:
 - native support for containers enabling reproducible analysis whilst minimising demand on system admin.
 - automated resource allocation for GPUs and storage volumes that are shared across multiple users.
 
+## Setting up K8s on your virtual machine
+
+To access the GPU system through Kubernetes you will need a virtual machine setup in the EIDF infrastructure.
+
 ## Interacting with a K8s cluster
 
 An overview of the key components of a K8s container can be seen on the [Kubernetes docs website](https://kubernetes.io/docs/concepts/overview/components/).

--- a/docs/services/gpuservice/training/L1_getting_started.md
+++ b/docs/services/gpuservice/training/L1_getting_started.md
@@ -13,7 +13,7 @@ Using K8s to manage the EIDFGPUS provides two key advantages:
 
 ## Setting up K8s on your virtual machine
 
-To access the GPU system through Kubernetes you will need a virtual machine setup in the EIDF infrastructure.
+To access the GPU system through Kubernetes you will need a virtual machine setup in the EIDF infrastructure. This requires request a virtual machine through this web page
 
 ## Interacting with a K8s cluster
 

--- a/docs/services/gpuservice/training/L1_getting_started.md
+++ b/docs/services/gpuservice/training/L1_getting_started.md
@@ -84,8 +84,8 @@ spec:
      nvidia.com/gpu: 1
 ```
 
-1. Save the file and exit the editor
-1. Run `kubectl create -f test_NBody.yml`
+1. Save the file (we are assuming you will use the fule `test_NBody.yml`, if you use a different filename you will need to update the command below) and exit the editor
+1. Run `kubectl create -f test_NBody.yml -n projectnamens` (the `-n projectnamens` specifies the namespace to use for permissions to create the pod, this should be your EIDF project name plus the letters "ns" at the end, i.e. eidf069ns) 
 1. This will output something like:
 
     ``` bash

--- a/docs/services/gpuservice/training/L1_getting_started.md
+++ b/docs/services/gpuservice/training/L1_getting_started.md
@@ -85,7 +85,7 @@ spec:
 ```
 
 1. Save the file and exit the editor
-1. Run `kubectl create -f test_NBody.yml'
+1. Run `kubectl create -f test_NBody.yml`
 1. This will output something like:
 
     ``` bash

--- a/docs/services/gpuservice/training/L1_getting_started.md
+++ b/docs/services/gpuservice/training/L1_getting_started.md
@@ -158,7 +158,7 @@ This is because K8s is allocating the pod to any free node irrespective of wheth
 
 The GPU resource request can be more specific by adding the type of product the pod is requesting to the node selector:
 
-- `nvidia.com/gpu.product: 'NVIDIA-A100-SXM4-80GB'`
+- `nvidia.com/gpu.product: 'NVIDIA-A100-SXM4-80GB'` (not all users have access to these GPUs)
 - `nvidia.com/gpu.product: 'NVIDIA-A100-SXM4-40GB'`
 - `nvidia.com/gpu.product: 'NVIDIA-A100-SXM4-40GB-MIG-3g.20gb'`
 - `nvidia.com/gpu.product: 'NVIDIA-A100-SXM4-40GB-MIG-1g.5gb'`

--- a/docs/services/gpuservice/training/L1_getting_started.md
+++ b/docs/services/gpuservice/training/L1_getting_started.md
@@ -85,7 +85,7 @@ spec:
 ```
 
 1. Save the file (we are assuming you will use the fule `test_NBody.yml`, if you use a different filename you will need to update the command below) and exit the editor
-1. Run `kubectl create -f test_NBody.yml -n projectnamens` (the `-n projectnamens` specifies the namespace to use for permissions to create the pod, this should be your EIDF project name plus the letters "ns" at the end, i.e. eidf069ns) 
+1. Run `kubectl create -f test_NBody.yml -n projectnamens` (the `-n projectnamens` specifies the namespace to use for permissions to create the pod, this should be your EIDF project name plus the letters "ns" at the end, i.e. `eidf069ns`) 
 1. This will output something like:
 
     ``` bash


### PR DESCRIPTION
Adding in indent to generateName: as without this the kubectl create fails.

# EIDF Documentation Pull Request

## Description

Updating K8s script in documentation as currently fails.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Incorrect Documentation


## What has to be reviewed

L1_getting_started.md

## Checklist

N/A
