### PR TITLE
the solution for insufficient shared memory size

### DIFF
--- a/docs/services/gpuservice/faq.md
+++ b/docs/services/gpuservice/faq.md
@@ -29,3 +29,23 @@ error: error validating "myjobfile.yml": error validating data: the server does 
 There may be an issue with the kubectl version that is being run. This can occur if installing in virtual environments or from packages repositories.
 
 The current version verified to operate with the GPU Service is v1.24.10. kubectl and the Kubernetes API version can suffer from version skew if not with a defined number of releases. More information can be found on this under the [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/).
+
+
+### Insufficient Shared Memory Size
+
+My SHM is very small, and it causes "OSError: [Errno 28] No space left on device" when I train a model using multi-GPU. How to increase SHM size?
+
+The default size of SHM is only 64M. You can mount an empty dir to /dev/shm to solve this problem:
+```yaml
+   spec:
+     containers:
+       - name: [NAME]
+         image: [IMAGE]
+         volumeMounts:
+           - mountPath: /dev/shm
+             name: dshm
+     volumes:
+       - name: dshm
+         emptyDir:
+            medium: Memory
+```


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Please include a summary of the change and any issues being addressed.

Add a solution of increasing SHM size.

It is useful to run single-node multi-gpus training.
The solution is about mounting an empty dir to /dev/shm.
Please also include relevant motivation and context.

The default shm size is 64M. It is too limited, so I met "sl = self._semlock = _multiprocessing.SemLock(
OSError: [Errno 28] No space left on device." when I train a model with single-node multi-gpus.

List any dependencies that are required for this change.

There is no additional dependency.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Incorrect Documentation

## What has to be reviewed

List the pages/sections that are to be reviewed.

Page: docs\services\gpuservice\faq.md
Section: Insufficient Shared Memory Size

## Checklist

- [ ] Documentation follows the project style guidelines
- [ ] Ensure Contact details contain Service Emails and Numbers
- [ ] Self-review of documentation using mkdocs on local system
- [ ] Spellcheck has been performed
- [ ] Pre-commit has been run and passed
