### PR TITLE
AG: added OMP Thread issue on Pytorch

### DIFF
--- a/docs/services/gpuservice/faq.md
+++ b/docs/services/gpuservice/faq.md
@@ -49,3 +49,30 @@ The default size of SHM is only 64M. You can mount an empty dir to /dev/shm to s
          emptyDir:
             medium: Memory
 ```
+
+### Pytorch Slow Performance Issues
+
+Pytorch on Kubernetes may operate slower than expected - much slower than an equivalent VM setup.
+
+Pytorch defaults to auto-detecting the number of OMP Threads and it will report an incorrect number of potential threads compared to your requested CPU core count. This is a consequence in operating in a container environment, the CPU information is reported by standard libraries and tools will be the node level information rather than your container.
+
+To help correct this issue, the environment variable OMP_NUM_THREADS should be set in the job submission file to the number of cores requested or less.
+
+This has been tested using:
+
+- OMP_NUM_THREADS=1
+- OMP_NUM_THREADS=(number of requested cores).
+
+Example fragment for a Bash command start:
+
+```yaml
+  containers:
+    - args:
+        - >
+          export OMP_NUM_THREADS=1;
+          python mypytorchprogram.py;
+      command:
+        - /bin/bash
+        - '-c'
+        - '--'
+```


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Identified issue in Pytorch and OMP threads. OMP thread count should be manually set rather than relying on autodetection.

Added this to the FAQ.

## Type of change

Please delete options that are not relevant.

- [x] New Documentation

## What has to be reviewed

GPU Service - FAQ

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed

Pre-existing failure in pre-commit on ultra2 doc page.