### PR TITLE
Update invocation of python3.8 on SDF

### DIFF
--- a/docs/services/cs2/run.md
+++ b/docs/services/cs2/run.md
@@ -43,7 +43,7 @@ To run a job on the cluster, you must create a Python virtual environment (venv)
 1. Create the venv
 
 ```bash
-/opt/python3.8/bin/python3.8 -m venv venv_cerebras_pt
+python3.8 -m venv venv_cerebras_pt
 ```
 
 1. Install the dependencies


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Updating instructions to reflect that `python3.8` is found in `/usr/bin` rather than `/opt/python3.8/bin`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Incorrect Documentation

## What has to be reviewed

Correctness of path.

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
