### PR TITLE
Remove reference to Drag and Drop in Guacamole

### DIFF
--- a/docs/access/virtualmachines-vdi.md
+++ b/docs/access/virtualmachines-vdi.md
@@ -58,7 +58,6 @@ by pressing &lt;Ctrl&gt; + &lt;Alt&gt; + &lt;Shift&gt; on a Windows PC client, o
 options, including:
 
 * [Reading from (and writing to) the clipboard of the remote desktop](https://guacamole.apache.org/doc/gug/using-guacamole.html#copying-pasting-text)
-* [Uploading and downloading files](https://guacamole.apache.org/doc/gug/using-guacamole.html#file-transfer)
 * [Zooming in and out of the remote display](https://guacamole.apache.org/doc/gug/using-guacamole.html#scaling-display)
 
 ### Clipboard Copy and Paste Functionality
@@ -87,4 +86,3 @@ are transmitted to your VM. Please contact the EIDF helpdesk at [eidf@epcc.ed.ac
 are experiencing difficulties with your keyboard mapping, and we will help to resolve this by changing some settings
 in the Guacamole VDI connection configuration.
 
-## Further information


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Remove ref to Guac Drag and Drop as that's not supported in EIDF

List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Incorrect Documentation
- [ ] Incomplete Documentation
- [ ] Missing Documentation
- [ ] Formatting
- [ ] New Documentation

## What has to be reviewed

List the pages/sections that are to be reviewed.

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
