### PR TITLE
Addresses namespace issue with kubectl usage

### DIFF
--- a/docs/services/gpuservice/faq.md
+++ b/docs/services/gpuservice/faq.md
@@ -10,6 +10,12 @@ The default access route to the GPU Service is via an EIDF DSC VM. The DSC VM wi
 
 Project Leads and Managers can access the kubeconfig file from the Project page in the Portal. Project Leads and Managers can provide the file on any of the project VMs or give it to individuals within the project.
 
+### Access to GPU Service resources in default namespace is 'Forbidden'
+
+```Error from server (Forbidden): error when creating <manifest-filename>: jobs is forbidden: User <user> cannot create resource "jobs" in API group "" in the namespace "default"```
+
+Some version of the above error is common when submitting jobs/pods to the GPU cluster using the kubectl command. This arises when you forgot to specify you are submitting job/pods to your project namespace, not the "default" namespace which you do not have permissions to use. Resubmitting the job/pod with `kubectl -n <project-gpu-service-namespace> create <manifest-filename>` should solve the issue.
+
 ### I can't mount my PVC in multiple containers or pods at the same time
 
 The current PVC provisioner is based on Ceph RBD. The block devices provided by Ceph to the Kubernetes PV/PVC providers cannot be mounted in multiple pods at the same time. They can only be accessed by one pod at a time, once a pod has unmounted the PVC and terminated, the PVC can be reused by another pod. The service development team is working on new PVC provider systems to alleviate this limitation.

--- a/docs/services/gpuservice/faq.md
+++ b/docs/services/gpuservice/faq.md
@@ -12,9 +12,9 @@ Project Leads and Managers can access the kubeconfig file from the Project page 
 
 ### Access to GPU Service resources in default namespace is 'Forbidden'
 
-```Error from server (Forbidden): error when creating <manifest-filename>: jobs is forbidden: User <user> cannot create resource "jobs" in API group "" in the namespace "default"```
+```Error from server (Forbidden): error when creating "myjobfile.yml": jobs is forbidden: User <user> cannot create resource "jobs" in API group "" in the namespace "default"```
 
-Some version of the above error is common when submitting jobs/pods to the GPU cluster using the kubectl command. This arises when you forgot to specify you are submitting job/pods to your project namespace, not the "default" namespace which you do not have permissions to use. Resubmitting the job/pod with `kubectl -n <project-gpu-service-namespace> create <manifest-filename>` should solve the issue.
+Some version of the above error is common when submitting jobs/pods to the GPU cluster using the kubectl command. This arises when you forgot to specify you are submitting job/pods to your project namespace, not the "default" namespace which you do not have permissions to use. Resubmitting the job/pod with `kubectl -n <project-gpu-service-namespace> create "myjobfile.yml"` should solve the issue.
 
 ### I can't mount my PVC in multiple containers or pods at the same time
 

--- a/docs/services/gpuservice/faq.md
+++ b/docs/services/gpuservice/faq.md
@@ -12,7 +12,7 @@ Project Leads and Managers can access the kubeconfig file from the Project page 
 
 ### Access to GPU Service resources in default namespace is 'Forbidden'
 
-```Error from server (Forbidden): error when creating "myjobfile.yml": jobs is forbidden: User <user> cannot create resource "jobs" in API group "" in the namespace "default"```
+```<Error from server (Forbidden): error when creating "myjobfile.yml": jobs is forbidden: User <user> cannot create resource "jobs" in API group "" in the namespace "default">```
 
 Some version of the above error is common when submitting jobs/pods to the GPU cluster using the kubectl command. This arises when you forgot to specify you are submitting job/pods to your project namespace, not the "default" namespace which you do not have permissions to use. Resubmitting the job/pod with `kubectl -n <project-namespace> create "myjobfile.yml"` should solve the issue.
 

--- a/docs/services/gpuservice/faq.md
+++ b/docs/services/gpuservice/faq.md
@@ -12,7 +12,9 @@ Project Leads and Managers can access the kubeconfig file from the Project page 
 
 ### Access to GPU Service resources in default namespace is 'Forbidden'
 
-```<Error from server (Forbidden): error when creating "myjobfile.yml": jobs is forbidden: User <user> cannot create resource "jobs" in API group "" in the namespace "default">```
+```bash
+Error from server (Forbidden): error when creating "myjobfile.yml": jobs is forbidden: User <user> cannot create resource "jobs" in API group "" in the namespace "default"
+```
 
 Some version of the above error is common when submitting jobs/pods to the GPU cluster using the kubectl command. This arises when you forgot to specify you are submitting job/pods to your project namespace, not the "default" namespace which you do not have permissions to use. Resubmitting the job/pod with `kubectl -n <project-namespace> create "myjobfile.yml"` should solve the issue.
 

--- a/docs/services/gpuservice/faq.md
+++ b/docs/services/gpuservice/faq.md
@@ -14,7 +14,7 @@ Project Leads and Managers can access the kubeconfig file from the Project page 
 
 ```Error from server (Forbidden): error when creating "myjobfile.yml": jobs is forbidden: User <user> cannot create resource "jobs" in API group "" in the namespace "default"```
 
-Some version of the above error is common when submitting jobs/pods to the GPU cluster using the kubectl command. This arises when you forgot to specify you are submitting job/pods to your project namespace, not the "default" namespace which you do not have permissions to use. Resubmitting the job/pod with `kubectl -n <project-gpu-service-namespace> create "myjobfile.yml"` should solve the issue.
+Some version of the above error is common when submitting jobs/pods to the GPU cluster using the kubectl command. This arises when you forgot to specify you are submitting job/pods to your project namespace, not the "default" namespace which you do not have permissions to use. Resubmitting the job/pod with `kubectl -n <project-namespace> create "myjobfile.yml"` should solve the issue.
 
 ### I can't mount my PVC in multiple containers or pods at the same time
 

--- a/docs/services/gpuservice/index.md
+++ b/docs/services/gpuservice/index.md
@@ -41,19 +41,19 @@ The current full specification of the EIDF GPU Service as of 14 February 2024:
 
 ## Service Access
 
-Users should have an [EIDF Account](../../access/project.md) as access to the EIDF GPU Service can only be obtained through an EIDF virtual machine.
+Users should have an [EIDF Account](../../access/project.md) as the EIDF GPU Service is only accessible through EIDF Virtual Machines.
 
-Project Leads can request access to the EIDF GPU Service from VMs in an existing project through a service request to the EIDF helpdesk.
+Existing projects can request access to the EIDF GPU Service through a service request to the [EIDF helpdesk](https://portal.eidf.ac.uk/queries/submit) or emailing eidf@epcc.ed.ac.uk .
 
-Otherwise, Project Leads need to apply for a new EIDF project and specify access to the EIDF GPU service.
+New projects wanting to using the GPU Service should include this in their EIDF Project Application.
 
 Each project will be given a namespace within the EIDF GPU service to operate in.
 
-Typically, the namespace is the same as the EIDF project code but with 'ns' appended, i.e. `eidf989ns` for a project with code 'eidf989'.
+This namespace will normally be the EIDF Project code appended with ’ns’, i.e. `eidf989ns` for a project with code 'eidf989'.
 
 Once access to the EIDF GPU service has been confirmed, Project Leads will be give the ability to add a kubeconfig file to any of the VMs in their EIDF project - information on access to VMs is available [here](../../access/virtualmachines-vdi.md).
 
-All EIDF VMs with the project kubeconfig file downloaded can access the EIDF GPU Service using the kubectl API.
+All EIDF VMs with the project kubeconfig file downloaded can access the EIDF GPU Service using the kubectl command line tool.
 
 The VM does not require to be GPU-enabled.
 
@@ -83,9 +83,7 @@ A standard project namespace has the following initial quota (subject to ongoing
 
     A project quota is the maximum proportion of the service available for use by that project.
 
-    This is a sum of all requested resources across all submitted jobs/pods/deployments within a project.
-
-    Any submitted resource requests that would exceed the total project quota will be rejected.
+    Any submitted job requests that would exceed the total project quota will be queued.
 
 ## Project Queues
 

--- a/docs/services/gpuservice/index.md
+++ b/docs/services/gpuservice/index.md
@@ -57,9 +57,9 @@ All EIDF VMs with the project kubeconfig file downloaded can access the EIDF GPU
 
 The VM does not require to be GPU-enabled.
 
-A quick check to see if a VM has access to the EIDF GPU service can be completed by typing `kubectl -n <project-gpu-service-namespace> get jobs` in to the command line.
+A quick check to see if a VM has access to the EIDF GPU service can be completed by typing `kubectl -n <project-namespace> get jobs` in to the command line.
 
-If this is first time you have connected to the GPU service the response should be `No resources found in <project-gpu-service-namespace> namespace`.
+If this is first time you have connected to the GPU service the response should be `No resources found in <project-namespace> namespace`.
 
 !!! important "EIDF GPU Service vs EIDF GPU-Enabled VMs"
 

--- a/docs/services/gpuservice/index.md
+++ b/docs/services/gpuservice/index.md
@@ -9,7 +9,7 @@ The EIDF GPU Service hosts 3G.20GB and 1G.5GB MIG variants which are approximate
 The service provides access to:
 
 - Nvidia A100 40GB
-- Nvidia 80GB
+- Nvidia A100 80GB
 - Nvidia MIG A100 1G.5GB
 - Nvidia MIG A100 3G.20GB
 - Nvidia H100 80GB
@@ -27,6 +27,7 @@ The current full specification of the EIDF GPU Service as of 14 February 2024:
 - 32 Nvidia H100 80 GB
 
 !!! important "Quotas"
+
     This is the full configuration of the cluster.
 
     Each project will have access to a quota across this shared configuration.
@@ -40,16 +41,29 @@ The current full specification of the EIDF GPU Service as of 14 February 2024:
 
 ## Service Access
 
-Users should have an [EIDF Account](../../access/project.md).
+Users should have an [EIDF Account](../../access/project.md) as access to the EIDF GPU Service can only be obtained through an EIDF virtual machine.
 
-Project Leads will be able to request access to the EIDF GPU Service for their project either during the project application process or through a service request to the EIDF helpdesk.
+Project Leads can request access to the EIDF GPU Service from VMs in an existing project through a service request to the EIDF helpdesk.
 
-Each project will be given a namespace to operate in and the ability to add a kubeconfig file to any of their Virtual Machines in their EIDF project - information on access to VMs is available [here](../../access/virtualmachines-vdi.md).
+Otherwise, Project Leads need to apply for a new EIDF project and specify access to the EIDF GPU service.
 
-All EIDF virtual machines can be set up to access the EIDF GPU Service. The Virtual Machine does not require to be GPU-enabled.
+Each project will be given a namespace within the EIDF GPU service to operate in.
+
+Once access to the EIDF GPU service has been confirmed, Project Leads will be give the ability to add a kubeconfig file to any of the VMs in their EIDF project - information on access to VMs is available [here](../../access/virtualmachines-vdi.md).
+
+All EIDF VMs with the project kubeconfig file downloaded can access the EIDF GPU Service using the kubectl API.
+
+The VM does not require to be GPU-enabled.
+
+A quick check to see if a VM has access to the EIDF GPU service can be completed by typing `kubectl -n <project-gpu-service-namespace> get jobs` in to the command line.
+
+If this is first time you have connected to the GPU service the response should be `No resources found in <project-gpu-service-namespace> namespace`.
 
 !!! important "EIDF GPU Service vs EIDF GPU-Enabled VMs"
-    The EIDF GPU Service is a container based service which is accessed from EIDF Virtual Desktop VMs. This allows a project to access multiple GPUs of different types.
+
+    The EIDF GPU Service is a container based service which is accessed from EIDF Virtual Desktop VMs. 
+    
+    This allows a project to access multiple GPUs of different types.
 
     An EIDF Virtual Desktop GPU-enabled VM is limited to a small number (1-2) of GPUs of a single type.
 
@@ -64,15 +78,26 @@ A standard project namespace has the following initial quota (subject to ongoing
 - GPU: 12
 
 !!! important "Quota is a maximum on a Shared Resource"
+    
     A project quota is the maximum proportion of the service available for use by that project.
-
-    During periods of high demand, Jobs will be queued awaiting resource availability on the Service.
-
-    This means that a project has access up to 12 GPUs but due to demand may only be able to access a smaller number at any given time.
+    
+    This is a sum of all requested resources across all submitted jobs/pods/deployments within a project.
+    
+    Any submitted resource requests that would exceed the total project quota will be rejected.
 
 ## Project Queues
 
 EIDF GPU Service is introducing the Kueue system in February 2024. The use of this is detailed in the [Kueue](kueue.md).
+
+!!! important "Job Queuing"
+
+    During periods of high demand, jobs will be queued awaiting resource availability on the Service.
+    
+    As a general rule, the higher the GPU/CPU/Memory resource request of a single job the longer it will wait in the queue before enough resources are free on a single node for it be allocated. 
+    
+    GPUs in high demand, such as Nvidia H100s, typically have longer wait times.
+
+    Furthermore, a project may have a quota of up to 12 GPUs but due to demand may only be able to access a smaller number at any given time.
 
 ## Additional Service Policy Information
 

--- a/docs/services/gpuservice/index.md
+++ b/docs/services/gpuservice/index.md
@@ -61,8 +61,8 @@ If this is first time you have connected to the GPU service the response should 
 
 !!! important "EIDF GPU Service vs EIDF GPU-Enabled VMs"
 
-    The EIDF GPU Service is a container based service which is accessed from EIDF Virtual Desktop VMs. 
-    
+    The EIDF GPU Service is a container based service which is accessed from EIDF Virtual Desktop VMs.
+
     This allows a project to access multiple GPUs of different types.
 
     An EIDF Virtual Desktop GPU-enabled VM is limited to a small number (1-2) of GPUs of a single type.
@@ -78,11 +78,11 @@ A standard project namespace has the following initial quota (subject to ongoing
 - GPU: 12
 
 !!! important "Quota is a maximum on a Shared Resource"
-    
+
     A project quota is the maximum proportion of the service available for use by that project.
-    
+
     This is a sum of all requested resources across all submitted jobs/pods/deployments within a project.
-    
+
     Any submitted resource requests that would exceed the total project quota will be rejected.
 
 ## Project Queues
@@ -92,9 +92,9 @@ EIDF GPU Service is introducing the Kueue system in February 2024. The use of th
 !!! important "Job Queuing"
 
     During periods of high demand, jobs will be queued awaiting resource availability on the Service.
-    
-    As a general rule, the higher the GPU/CPU/Memory resource request of a single job the longer it will wait in the queue before enough resources are free on a single node for it be allocated. 
-    
+
+    As a general rule, the higher the GPU/CPU/Memory resource request of a single job the longer it will wait in the queue before enough resources are free on a single node for it be allocated.
+
     GPUs in high demand, such as Nvidia H100s, typically have longer wait times.
 
     Furthermore, a project may have a quota of up to 12 GPUs but due to demand may only be able to access a smaller number at any given time.

--- a/docs/services/gpuservice/index.md
+++ b/docs/services/gpuservice/index.md
@@ -49,6 +49,8 @@ Otherwise, Project Leads need to apply for a new EIDF project and specify access
 
 Each project will be given a namespace within the EIDF GPU service to operate in.
 
+Typically, the namespace is the same as the EIDF project code but with 'ns' appended, i.e. `eidf989ns` for a project with code 'eidf989'.
+
 Once access to the EIDF GPU service has been confirmed, Project Leads will be give the ability to add a kubeconfig file to any of the VMs in their EIDF project - information on access to VMs is available [here](../../access/virtualmachines-vdi.md).
 
 All EIDF VMs with the project kubeconfig file downloaded can access the EIDF GPU Service using the kubectl API.


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Updates text in GPU Service Overview and FAQ in response to user queries:

### Attempts to access to GPU cluster without adding kubeconfig files

- Rewrote the service access section to try to highlight that it is the kubeconfig files that allows any VM within a project to access the service

### Confusion around total quota and long queue wait times

- Separated description of quota and job queueing by creating a new entry in the Project Queue section

### Users are submitting their requests to 'default' namespace not their project namespace

- New example use of kubectl in Overview page that explicitly uses -n flag
- Adds new section in FAQ giving an example forbidden error and the solution using the -n flag when using kubectl 
- Fixes #136 

## Type of change

- [ x ] Missing Documentation

## What has to be reviewed

Added new section to GPU Service FAQ:

 - Access to GPU Service resources in default namespace is 'Forbidden'

Rewrote sections in GPU Service Overview for clarity:

- Service Access
- Project Quotas
- Project Queues

## Checklist

- [ x ] Documentation follows the project style guidelines
- [ x ] Ensure Contact details contain Service Emails and Numbers
- [ x ] Self-review of documentation using mkdocs on local system
- [ x ] Spellcheck has been performed
- [ x ] Pre-commit has been run and passed
