### PR TITLE
Minor fix to local build config

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,4 +107,4 @@ nav:
   - "EIDF Frequently Asked Questions": faq/index.md
 
 
-dev_addr: 0.0.0.0:8000
+dev_addr: localhost:8000


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Minor changes to make it easier to view the docs built locally

1. Change `dev_addr` to `localhost` instead of `0.0.0.0` as the latter will not open now on latest browsers due to security issue on the use of `0.0.0.0` (e.g. https://www.theregister.com/2024/08/09/0000_day_bug/)

## Type of change

- [x] Update to docs build

## What has to be reviewed

`mkdocs.yml`

## Checklist

- [ ] Documentation follows the project style guidelines
- [ ] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [ ] Spellcheck has been performed
- [x] Pre-commit has been run and passed
