### PR TITLE
Add Warning, SSH access to shs-sdf01 is strictly one-way

### DIFF
--- a/docs/safe-haven-services/using-the-hpc-cluster.md
+++ b/docs/safe-haven-services/using-the-hpc-cluster.md
@@ -20,6 +20,9 @@ Minor software changes will be made as soon as admin effort can be allocated. Ma
 
 Login to the HPC system is from the project VM using SSH and is not direct from the VDI. The HPC cluster accounts are the same accounts used on the project VMs, with the same username and password. All project data access on the HPC system is private to the project accounts as it is on the VMs, but it is important to understand that the TRE HPC cluster is shared by projects in other TRE Safe Havens.
 
+!!! warning "One-Way SSH Access Only"
+    SSH access to shs-sdf01 is strictly one-way from the project VM to the HPC system. Reverse SSH from the HPC system back to the project VM or any other system is not permitted.
+
 To login to the HPC cluster from the project VMs use `ssh shs-sdf01` from an xterm. If you wish to avoid entry of the account password for every SSH session or remote command execution you can use SSH key authentication by following the [SSH key configuration instructions here](https://hpc-wiki.info/hpc/Ssh_keys). SSH key passphrases are not strictly enforced within the Safe Haven but are strongly encouraged.
 
 ## Running Jobs


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

This pull request addresses the update of SSH access limitations and usage guidelines for the TRE HPC system. The goal is to provide clarity on SSH access restrictions, one-way access from the project VM to the HPC node.

The motivation behind this update is to ensure that all users understand the access constraints to the TRE HPC cluster.

No dependencies are required for this change.

Fixes # 179

## Type of change

Please delete options that are not relevant.

- [ ] Incorrect Documentation
- [ ] Incomplete Documentation
- [x] Missing Documentation
- [ ] Formatting
- [ ] New Documentation

## What has to be reviewed

The following sections of the documentation need to be reviewed:
- https://github.com/EPCCed/eidf-docs/blob/main/docs/safe-haven-services/using-the-hpc-cluster.md#hpc-login

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
