### PR TITLE
Update links after migration to docs.eidf.ac.uk

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ extra_css:
   - stylesheets/access.css
 
 site_name: EIDF User Documentation
-site_url: https://epcced.github.io/eidf-docs/
+site_url: https://docs.eidf.ac.uk/
 repo_url: https://github.com/EPCCed/eidf-docs/
 repo_name: EPCCed/eidf-docs.git
 edit_uri: edit/main/docs/


### PR DESCRIPTION


# EIDF Documentation Pull Request

## Description

Images were not showing after the migration of the old URL to docs.eidf.ac.uk.

Have removed "/eidf/docs" from the image URLs.

Updated site in mkdocs to reflect new URL and enable consistent checks with prod

Fixes #181 

## Type of change

Please delete options that are not relevant.

- [x] Incorrect Documentation
- [ ] Incomplete Documentation
- [ ] Missing Documentation
- [ ] Formatting
- [ ] New Documentation

## What has to be reviewed

List the pages/sections that are to be reviewed.

## Checklist

- [x] Documentation follows the project style guidelines
- [x]  Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
