### PR TITLE
Fix typos in GPU Service tutorials

### DIFF
--- a/docs/services/gpuservice/training/L2_requesting_persistent_volumes.md
+++ b/docs/services/gpuservice/training/L2_requesting_persistent_volumes.md
@@ -48,7 +48,7 @@ spec:
  storageClassName: csi-rbd-sc
 ```
 
-You create a persistent volume by passing the yaml file to kubectl like a pod specification yaml `kubectl -n <project-namespace> create <PVC specification yaml>`
+You create a persistent volume by passing the yaml file to kubectl like a pod specification yaml `kubectl -n <project-namespace> create -f <PVC specification yaml>`
 Once you have successfully created a persistent volume you can interact with it using the standard kubectl commands:
 
 - `kubectl -n <project-namespace> delete pvc <PVC name>`

--- a/docs/services/gpuservice/training/L3_running_a_pytorch_task.md
+++ b/docs/services/gpuservice/training/L3_running_a_pytorch_task.md
@@ -77,7 +77,7 @@ spec:
 1. Delete the lightweight job
 
     ``` bash
-    kubectl -n <project-namespace> delete job lightweight-job-<identifier>
+    kubectl -n <project-namespace> delete job lightweight-job
     ```
 
 ### Example lightweight job specification


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Fixed some small typos found while following the EIDF GPU Service Tutorials.

Fixes #183 #184 

## Type of change

Please delete options that are not relevant.

- [x] Incorrect Documentation

## What has to be reviewed

1. The kubectl command for creating a persistent volume at 
https://docs.eidf.ac.uk/services/gpuservice/training/L2_requesting_persistent_volumes/#example-persistentvolumeclaim

2. The kubectl command for deleting the lightweight job ("Delete the lightweight job" under the "Transfer code/data to persistent volume" section) at
https://docs.eidf.ac.uk/services/gpuservice/training/L3_running_a_pytorch_task/#transfer-codedata-to-persistent-volume

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
