### PR TITLE
Update S3 docs: include fix for integrity protection that is not supported by Ceph S3

### DIFF
--- a/docs/services/s3/tutorial.md
+++ b/docs/services/s3/tutorial.md
@@ -117,7 +117,7 @@ In boto3 version 1.36, a breaking change was introduced that adopts new default 
 (see [https://github.com/boto/boto3/issues/4392](https://github.com/boto/boto3/issues/4392)). If you see this error
 
 ```text
-An error occurred (XAmzContentSHA256Mismatch) when calling the UploadPart operation
+botocore.exceptions.ClientError: An error occurred (XAmzContentSHA256Mismatch) when calling the PutObject operation: None
 ```
 
 use the following configuration for your client:

--- a/docs/services/s3/tutorial.md
+++ b/docs/services/s3/tutorial.md
@@ -1,9 +1,5 @@
 # Tutorial
 
-Buckets owned by an EIDF project are placed in a tenancy in the EIDF S3 Service.
-The project code is a prefix on the bucket name, separated by a colon (`:`), for example `eidfXX1:somebucket`.
-Note that some S3 client libraries do not accept bucket names in this format.
-
 ## AWS CLI
 
 The following examples use the AWS Command Line Interface (AWS CLI) to connect to EIDF S3.
@@ -28,6 +24,7 @@ Credentials file:
 [default]
 aws_access_key_id=<key>
 aws_secret_access_key=<secret>
+endpoint_url=https://s3.eidf.ac.uk
 ```
 
 Environment variables:
@@ -35,40 +32,39 @@ Environment variables:
 ```bash
 export AWS_ACCESS_KEY_ID=<key>
 export AWS_SECRET_ACCESS_KEY=<secret>
+export AWS_ENDPOINT_URL=https://s3.eidf.ac.uk
 ```
-
-The parameter `--endpoint-url https://s3.eidf.ac.uk` must always be set when calling a command.
 
 ### Commands
 
 List the buckets in your account:
 
 ```bash
-aws s3 ls --endpoint-url https://s3.eidf.ac.uk
+aws s3 ls
 ```
 
 Create a bucket:
 
 ```bash
-aws s3api create-bucket --bucket <bucketname> --endpoint-url https://s3.eidf.ac.uk
+aws s3api create-bucket --bucket <bucketname>
 ```
 
 Upload a file:
 
 ```bash
-aws s3 cp <filename> s3://<bucketname> --endpoint-url https://s3.eidf.ac.uk
+aws s3 cp <filename> s3://<bucketname>
 ```
 
 Check that the file above was uploaded successfully by listing objects in the bucket:
 
 ```bash
-aws s3 ls s3://<bucketname> --endpoint-url https://s3.eidf.ac.uk
+aws s3 ls s3://<bucketname>
 ```
 
 To read from a public bucket without providing credentials, add the option `--no-sign-request` to the call:
 
 ```bash
-aws s3 ls s3://<bucketname> --no-sign-request --endpoint-url https://s3.eidf.ac.uk
+aws s3 ls s3://<bucketname> --no-sign-request
 ```
 
 ## Python using `boto3`
@@ -85,7 +81,68 @@ python -m pip install boto3
 
 ### Usage
 
-By default, the `boto3` Python library raises an error that bucket names with a colon `:` (as used by the EIDF S3 Service) are invalid, so we have to switch off the bucket name validation:
+#### Connect
+
+Create an S3 client resource:
+
+```python
+import boto3
+s3 = boto3.resource('s3')
+```
+
+#### List buckets
+
+```python
+for bucket in s3.buckets.all():
+    print(f'{bucket.name}')
+```
+
+#### List objects in a bucket
+
+```python
+bucket_name = 'somebucket'
+bucket = s3.Bucket(bucket_name)
+for obj in bucket.objects.all():
+    print(f'{obj.key}')
+```
+
+#### Uploading files to a bucket
+
+```python
+bucket = s3.Bucket(bucket_name)
+bucket.upload_file('./somedata.csv', 'somedata.csv')
+```
+
+In boto3 version 1.36, a breaking change was introduced that adopts new default integrity protections which is not currently supported by EIDF S3
+(see [https://github.com/boto/boto3/issues/4392](https://github.com/boto/boto3/issues/4392)). If you see this error
+
+```text
+An error occurred (XAmzContentSHA256Mismatch) when calling the UploadPart operation
+```
+
+use the following configuration for your client:
+
+```python
+from botocore.config import Config
+config = Config(
+    request_checksum_calculation="when_required",
+    response_checksum_validation="when_required",
+)
+s3 = boto3.resource('s3', config=config)
+```
+
+Then upload your files as shown above.
+
+### Accessing buckets in other projects
+
+Buckets owned by an EIDF project are placed in a tenancy in the EIDF S3 Service.
+The project code is a prefix on the bucket name, separated by a colon (`:`), for example `eidfXX1:somebucket`.
+
+This is only relevant when accessing buckets outside your project tenancy - if you access buckets in your own project you can ignore this section.
+
+By default, the `boto3` Python library raises an error that bucket names with a colon `:` (as used by the EIDF S3 Service) are invalid.
+
+When accessing a bucket with the project code prefix, switch off the bucket name validation:
 
 ```python
 import boto3
@@ -95,31 +152,11 @@ s3 = boto3.resource('s3', endpoint_url='https://s3.eidf.ac.uk')
 s3.meta.client.meta.events.unregister('before-parameter-build.s3', validate_bucket_name)
 ```
 
-List buckets:
-
-```python
-for bucket in s3.buckets.all():
-    print(f'{bucket.name}')
-```
-
-List objects in a bucket:
-
-```python
-project_code = 'eidfXXX'
-bucketname = 'somebucket'
-bucket = s3.Bucket(f'{project_code}:{bucket_name}')
-for obj in bucket.objects.all():
-    print(f'{obj.key}')
-```
-
-Upload a file to a bucket:
-
-```python
-bucket = s3.Bucket(f'{project_code}:{bucket_name}')
-bucket.upload_file('./somedata.csv', 'somedata.csv')
-```
-
 ## Access policies
+
+Buckets owned by an EIDF project are placed in a tenancy in the EIDF S3 Service.
+The project code is a prefix on the bucket name, separated by a colon (`:`), for example `eidfXX1:somebucket`.
+Note that some S3 client libraries do not accept bucket names in this format.
 
 Bucket permissions use IAM policies. You can grant other accounts (within the same project or from other projects) read or write access to your buckets.
 For example to grant permissions to put, get, delete and list objects in bucket `eidfXX1:somebucket` to the account `account2` in project `eidfXX2`:


### PR DESCRIPTION
Include fix to turn off integrity protection for boto3. This was a breaking change in boto3 1.36.0 and is not supported by Ceph S3.

# EIDF Documentation Pull Request

## Description

Please include a summary of the change and any issues being addressed.

Please also include relevant motivation and context.

List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Incorrect Documentation
- [ ] Incomplete Documentation
- [x] Missing Documentation
- [ ] Formatting
- [x] New Documentation

## What has to be reviewed

docs/services/s3/tutorial.md

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
