### PR TITLE
TRE: add warning regarding usage of container CLIs

### DIFF
--- a/docs/safe-haven-services/tre-container-user-guide/using-containers-in-the-tre.md
+++ b/docs/safe-haven-services/tre-container-user-guide/using-containers-in-the-tre.md
@@ -2,6 +2,11 @@
 
 Once you have built and tested your container, you are ready to start using it within the TRE.
 
+!!! warning "Do not use container CLIs directly"
+    The CES wrapper scripts **must** be used to run containers in the TRE. This is to ensure that the correct data directories are automatically made available.
+
+    You **must not** use commands such as `podman run ...` or `docker run ...` directly.
+
 ## Pulling a container into the TRE
 
 Containers can only be used on the TRE desktop hosts using shell commands. And containers can only be pulled from the GitHub Container Registry (GHCR) into the TRE using a `ces-pull` script. Hence containers must be pushed to GHCR for them to be used in the TRE.


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Adds a warning to instruct users not to call `docker` or `podman` commands directly.

## Type of change

Please delete options that are not relevant.

- [ ] Incorrect Documentation
- [ ] Incomplete Documentation
- [ ] Missing Documentation
- [ ] Formatting
- [x] New Documentation

## What has to be reviewed

As per the `Files changed` tab.

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
