### PR TITLE
Updated TRE container examples and SH access links

### DIFF
--- a/docs/safe-haven-services/safe-haven-access.md
+++ b/docs/safe-haven-services/safe-haven-access.md
@@ -20,7 +20,7 @@ Registration of the user mobile phone number is managed by the Safe Haven IG con
 
 The second step in the access process is for the user to login to the Safe Haven service remote desktop gateway so that a project desktop connection can be chosen. The user is prompted for a Safe Haven service account identity.
 
-   ![VDI-Safe-Haven-Login-Page](/eidf-docs/images/access/UoE-Data-Safe-Haven-VDI-Login.png){: class="border-img"}
+   ![VDI-Safe-Haven-Login-Page](/docs/images/access/UoE-Data-Safe-Haven-VDI-Login.png){: class="border-img"}
    *VDI Safe Haven Service Login Page*
 
 Safe Haven accounts are managed by the Safe Haven IG controller and research project co-ordination teams by submitting and confirming user account changes through the dedicated service help desk via email.
@@ -29,7 +29,7 @@ Safe Haven accounts are managed by the Safe Haven IG controller and research pro
 
 The third stage in the process is to select the virtual connection from those available on the account's home page. An example home page is shown below offering two connection options to the same virtual machine. Remote desktop connections will have an \_rdp suffix and SSH terminal connections have an \_ssh suffix. The most recently used connections are shown as screen thumbnails at the top of the page and all the connections available to the user are shown in a tree list below this.
 
-   ![VDI-Connections-Available-Page](/eidf-docs/images/access/vdi-home-screen.png){: class="border-img"}
+   ![VDI-Connections-Available-Page](/docs/images/access/vdi-home-screen.png){: class="border-img"}
    *VM connections available home page*
 
 The remote desktop gateway software used in the Safe Haven services in the TRE is the Apache Guacamole web application. Users new to this application can [find the user manual here](https://guacamole.apache.org/doc/gug/using-guacamole.html). It is recommended that users read this short guide, but note that the data sharing features such as copy and paste, connection sharing, and file transfers are disabled on all connections in the TRE Safe Havens.

--- a/docs/safe-haven-services/tre-container-user-guide/container-examples.md
+++ b/docs/safe-haven-services/tre-container-user-guide/container-examples.md
@@ -1,26 +1,30 @@
 # Container Examples
 
-To help with writing your own Dockerfiles to run within a Trusted Research Environment via the Container Execution Service, we have provided a set of example Dockerfiles for commonly used software stacks. These show examples of how to set up containers with non-root user access, as well as other best practices for developing secure containers.
+To help with writing your own Dockerfiles to run within a Trusted Research Environment via the Container Execution Service, we have provided a set of examples for commonly used software stacks, which can be found in our [TRE Container Samples repository](https://github.com/EPCCed/tre-container-samples/tree/main).
 
-To request access to these container examples please contact the [EIDF Helpdesk](https://portal.eidf.ac.uk/queries/submit) referencing this page, otherwise send your query by email to [eidf@epcc.ed.ac.uk](mailto:eidf@epcc.ed.ac.uk) with the subject line "TRE Container Support".
+Please contact your Service Manager if you need further support with the use of containers available in the [EPCC TRE Container Samples epository](https://github.com/EPCCed/tre-container-samples/tree/main).
 
 ## Example Containers
 
-| Software Stack   |   Comments |
+| Public examples   |   Comments |
+| ---------------  |   -------- |
+| Julia            |  |
+| Octave           |  |
+| PostGreSQL       |  |
+| Python           |  |
+| Quarto           | separate containers for R and Jupyter |
+| Rocker           |  interactive |
+
+Additional examples can be made available on demand. To do so, please contact the [EIDF Helpdesk](https://portal.eidf.ac.uk/queries/submit) referencing this page, otherwise send your query by email to [eidf@epcc.ed.ac.uk](mailto:eidf@epcc.ed.ac.uk) with the subject line "TRE Container Support".
+ß
+| Available on demand   |   Comments |
 | ---------------  |   -------- |
 | Freesurfer       |            |
 | Jamovi           |            |
-| Julia            |   |
-| Jupyter Notebook | non-interactive at present |
 | MinIO S3         |  |
 | Nextflow         |  |
-| NVIDIA-Rapids    |  basic/minimal packages |
-| Octave           |  |
-| PostGreSQL       |  |
 | PSPP             |  |
 | Python           |  |
-| Pytorch          |  |
-| Quarto           | separate containers for R and Jupyter |
 | Stata            |
 
-Most of these containers are minimum working examples, they are not fully fledged applications or workflow examples, but provided a template for setting up the technical parts of the containerisation process, such as user mapping, and mapping to any required `safe_data` folders or similar.
+Most of these containers are minimum working examples, they are not fully fledged applications or workflow examples, but provide a template for setting up the technical parts of the containerisation process, such as user mapping, and mapping to any required `safe_data` folders or similar. Please refer to the `README` in each example for guidance on how to use the container.


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Changed the TRE containers user guide `container-examples.md` file as discussed with Kostas and the team and the image links in the `safe-haven-access.md` document, which had an incorrect path. 

## Type of change

Please delete options that are not relevant.

- [X] Formatting
- [X] New Documentation

## What has to be reviewed

safe-haven-services/tre-container-user-guide/container-examples.md
safe-haven-services/safe-haven-access.md

## Checklist

- [X] Documentation follows the project style guidelines
- [X] Ensure Contact details contain Service Emails and Numbers
- [X] Self-review of documentation using mkdocs on local system
- [X] Spellcheck has been performed
- [X] Pre-commit has been run and passed
