### PR TITLE
Fix for S3 AWS CLI boto 1.36 default integrity protection

### DIFF
--- a/docs/services/s3/tutorial.md
+++ b/docs/services/s3/tutorial.md
@@ -25,7 +25,12 @@ Credentials file:
 aws_access_key_id=<key>
 aws_secret_access_key=<secret>
 endpoint_url=https://s3.eidf.ac.uk
+
+request_checksum_calculation=when_required
+response_checksum_validation=when_required
 ```
+
+The last two lines are required since boto3 version 1.36 when a breaking change was introduced that adopts new default integrity protections which is not currently supported by EIDF S3.
 
 Environment variables:
 


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Fix for S3 AWS CLI boto 1.36 default integrity protection

## Type of change

Please delete options that are not relevant.

- [ ] Incorrect Documentation
- [ ] Incomplete Documentation
- [x] Missing Documentation
- [ ] Formatting
- [ ] New Documentation

## What has to be reviewed

List the pages/sections that are to be reviewed.

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
