### PR TITLE
Add simple imagenet vision classification model tutorial

### DIFF
--- a/docs/services/cerebras/run.md
+++ b/docs/services/cerebras/run.md
@@ -24,10 +24,32 @@ Edit the file `/<path_to_your_venv>/lib/python3.8/site-packages/cerebras/applian
 
 Run as per the normal Cerebras documentation. It is advisable to run codes inside a `tmux` session so you can return to them without having to leave SSH sessions active whilst jobs run.
 
-## Example training Llama4b on a single CS3
+### Example training Llama4b on a single CS3
 
 With a suitably configured venv as above, and the modelzoo checked out:
 
 - Copy `/home/y26/shared/params_tr.yaml` to `<your modelzoo checkout>/src/cerebras/modelzoo/models/nlp/llama/configs/`
 - Navigate to `<your modelzoo checkout>/src/cerebras/modelzoo/models/nlp/llama/`
 - Run using `python run.py CSX --num_csx=1 --mode train --params configs/params_tr.yaml --mount_dirs /home/<your_project>/<your_project>/<your username> /home/y26/shared/ --python_paths <path to your modelzoo checkout>/src/ --max_steps 50 --model_dir llama4b_u3`
+
+### Example: Training Vision Transformer on ImageNet Mini
+
+This tutorial will train a toy Visual transformer on a collection of captioned data, the produced model being able to input and image and output a caption
+
+We make use of the [imagenet-mini](https://www.kaggle.com/datasets/ifigotin/imagenetmini-1000/) dataset,  a subset of 1000 samples from the [ImageNet](https://www.image-net.org/) dataset 
+
+1. Set up your virtual environment as described above
+2. Copy the training configuration:
+
+    ```bash
+    cp /home/y26/shared/params_vit_imagenet.yaml ~/
+    ```
+
+3. Run the training job:
+
+    ```bash
+
+    cszoo fit params_vit_imagenet.yaml --num_csx=1 \
+      --mount_dirs /home/y26/shared/ /home/<your_project>/<your_project>/<your_username>/ \
+      --python_paths /home/<your_project>/<your_project>/<your_username>/modelzoo/src
+    ```

--- a/docs/services/cerebras/run.md
+++ b/docs/services/cerebras/run.md
@@ -34,18 +34,25 @@ With a suitably configured venv as above, and the modelzoo checked out:
 
 ### Example: Training Vision Transformer on ImageNet Mini
 
-This tutorial will train a toy Visual transformer on a collection of captioned data, the produced model being able to input and image and output a caption
+This tutorial will train a toy Visual transformer on a collection of captioned data, the produced model being able to input and image and output a caption.
 
-We make use of the [imagenet-mini](https://www.kaggle.com/datasets/ifigotin/imagenetmini-1000/) dataset,  a subset of 1000 samples from the [ImageNet](https://www.image-net.org/) dataset
+We make use of the [imagenet-mini](https://www.kaggle.com/datasets/ifigotin/imagenetmini-1000/) dataset,  a subset of 1000 samples from the [ImageNet](https://www.image-net.org/) dataset.
 
 1. Set up your virtual environment as described above
-2. Copy the training configuration:
+2. Create a space in which the model will be stored
 
     ```bash
-    cp /home/y26/shared/params_vit_imagenet.yaml ~/
+    mkdir -p ~/imagenet_tutorial
+    cd ~/imagenet_tutorial
     ```
 
-3. Run the training job:
+3. Copy the training configuration:
+
+    ```bash
+    cp /home/y26/shared/params_vit_imagenet.yaml ~/imagenet_tutorial
+    ```
+
+4. Run the training job:
 
     ```bash
 

--- a/docs/services/cerebras/run.md
+++ b/docs/services/cerebras/run.md
@@ -36,7 +36,7 @@ With a suitably configured venv as above, and the modelzoo checked out:
 
 This tutorial will train a toy Visual transformer on a collection of captioned data, the produced model being able to input and image and output a caption
 
-We make use of the [imagenet-mini](https://www.kaggle.com/datasets/ifigotin/imagenetmini-1000/) dataset,  a subset of 1000 samples from the [ImageNet](https://www.image-net.org/) dataset 
+We make use of the [imagenet-mini](https://www.kaggle.com/datasets/ifigotin/imagenetmini-1000/) dataset,  a subset of 1000 samples from the [ImageNet](https://www.image-net.org/) dataset
 
 1. Set up your virtual environment as described above
 2. Copy the training configuration:

--- a/docs/services/cerebras/run.md
+++ b/docs/services/cerebras/run.md
@@ -29,8 +29,9 @@ Run as per the normal Cerebras documentation. It is advisable to run codes insid
 With a suitably configured venv as above, and the modelzoo checked out:
 
 - Copy `/home/y26/shared/params_tr.yaml` to `<your modelzoo checkout>/src/cerebras/modelzoo/models/nlp/llama/configs/`
+- Adjust the copied `params_tr.yaml` config to reduce the `max_steps` field to `50`
 - Navigate to `<your modelzoo checkout>/src/cerebras/modelzoo/models/nlp/llama/`
-- Run using `python run.py CSX --num_csx=1 --mode train --params configs/params_tr.yaml --mount_dirs /home/<your_project>/<your_project>/<your username> /home/y26/shared/ --python_paths <path to your modelzoo checkout>/src/ --max_steps 50 --model_dir llama4b_u3`
+- Run using `cszoo fit --num_csx=1 configs/params_tr.yaml --mount_dirs /home/eidf114/eidf114/bc-eidfstaff/  /home/y26/shared/ --python_paths ~/modelzoo/src/ --model_dir llama4b_u3`
 
 ### Example: Training Vision Transformer on ImageNet Mini
 


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Have added a simple toy vision model classification tutorial for training a vision transformer on a small subset of the Imagenet dataset using Cerebras 

## Type of change

Please delete options that are not relevant.

- [x] New Documentation

## What has to be reviewed

List the pages/sections that are to be reviewed.


## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
