### PR TITLE
Fixed CONTRIBUTING.md formatting to satisfy 'pre-commit run --all-fil…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,30 +2,22 @@
 
 ## Process
 
-1. Identify Contribution - look at open issues, review existing
-   documentation, look for gaps in documentation. 
-2. Fork the documentation repository on GitHub and clone the fork to
-   your local system. See [Fork a GitHub
-   Repository](https://help.github.com/articles/fork-a-repo/). 
-3. Make Edits and Additions to local copy. See below for setting up an
-   editing environment.
-4. Proof read and run pre-commit tests on local copy.
-5. Update your forked repository on Github.
-6. Create a Pull Request to merge your changes to the main
-   documentation repository. Where possible you can assign this to a
-   member of the EIDF Service team for review and merging, do not
-   merge your own pull requests. See [Open a Pull
-   Request](https://help.github.com/articles/using-pull-requests/).
+1. Identify Contribution - look at open issues, review existing documentation, look for gaps in documentation.
+1. Fork the documentation repository on GitHub and clone the fork to your local system. See [Fork a GitHub Repository](https://help.github.com/articles/fork-a-repo/).
+1. Make Edits and Additions to local copy. See below for setting up an editing environment.
+1. Proof read and run pre-commit tests on local copy.
+1. Update your forked repository on Github.
+1. Create a Pull Request to merge your changes to the main documentation repository. Where possible you can assign this to a member of the EIDF Service team for review and merging, do not merge your own pull requests. See [Open a Pull Request](https://help.github.com/articles/using-pull-requests/).
 
 ## Setting up an editing environment
 
 ### Requirements
 
-- Git
-- Python 3.12+
-- Pip
-- Ruby 3.0+
-- Virtualenv, Conda (or equivalent)
+* Git
+* Python 3.12+
+* Pip
+* Ruby 3.0+
+* Virtualenv, Conda (or equivalent)
 
 ### Install Ruby
 
@@ -37,10 +29,7 @@ Install Ruby using a package manager appropriate to your operating system. For e
 
 ### Install Material for mkdocs via Pip and Requirements.txt
 
-You should edit the documentation in an editor of your choice but you should set up
-the required packages in a virtual environment. To ensure that you are using a compatible
-set of packages for a virtual environment for editing the documentation, a `requirements.txt`
-file is provided in the repository. You can install these requirements using Pip.
+You should edit the documentation in an editor of your choice but you should set up the required packages in a virtual environment. To ensure that you are using a compatible set of packages for a virtual environment for editing the documentation, a `requirements.txt` file is provided in the repository. You can install these requirements using Pip.
 
 ```bash
    python3 -m venv </path/to/new/virtual/environment>
@@ -57,15 +46,11 @@ You can also create the mkdocs environment using Conda and the `conda-requiremen
 
 ### Docker Materials for mkdocs
 
-You can use [Material for mkdocs](https://squidfunk.github.io/mkdocs-material/getting-started/)
-in Docker containers. The documentation for
-Material contains guidance on how to operate via Docker.
+You can use [Material for mkdocs](https://squidfunk.github.io/mkdocs-material/getting-started/) in Docker containers. The documentation for Material contains guidance on how to operate via Docker.
 
 ## Building the documentation on a local machine
 
-Once Material for mkdocs is installed, you can preview the site locally using the
-[instructions in the Material for mkdocs
-documentation](https://squidfunk.github.io/mkdocs-material/creating-your-site/#previewing-as-you-write).
+Once Material for mkdocs is installed, you can preview the site locally using the [instructions in the Material for mkdocs documentation](https://squidfunk.github.io/mkdocs-material/creating-your-site/#previewing-as-you-write).
 
 ### Local install quick start
 
@@ -75,9 +60,7 @@ In the root directory of your cloned repository, you can run:
    mkdocs serve
 ```
 
-This will start a local web server which your browser can connect to
-allowing you to view the updated documentation. The default port is
-8000. You can run the server on a different port as follows, for example:
+This will start a local web server which your browser can connect to allowing you to view the updated documentation. The default port is 8000. You can run the server on a different port as follows, for example:
 
 ```bash
    mkdocs serve -a localhost:9999
@@ -85,21 +68,15 @@ allowing you to view the updated documentation. The default port is
 
 ## Making changes
 
-The documentation consists of a series of Markdown files which have the `.md`
-extension. These files are then automatically converted to HTML and
-combined into the web version of the documentation by mkdocs. It is
-important that when editing the files the syntax of the Markdown files is
-followed. If there are any errors in your changes the build will fail
-and the documentation will not update, you can test your build locally
-by running `mkdocs serve`. The easiest way to learn what files should look
-like is to read the Markdown files already in the repository.
+The documentation consists of a series of Markdown files which have the `.md` extension. These files are then automatically converted to HTML and combined into the web version of the documentation by mkdocs.
+
+It is important that when editing the files the syntax of the Markdown files is followed. If there are any errors in your changes the build will fail and the documentation will not update, you can test your build locally by running `mkdocs serve`.
+
+The easiest way to learn what files should look like is to read the Markdown files already in the repository.
 
 ## Pre-commit
 
-Pre-commit will run a markdown linter configured with current rules
-for the EIDF documentation. Your pull request should indicate that you
-have done this and fixed issues that arise. Pre-commit is installed
-by the requirements files documented earlier.
+Pre-commit will run a markdown linter configured with current rules for the EIDF documentation. Your pull request should indicate that you have done this and fixed issues that arise. Pre-commit is installed by the requirements files documented earlier.
 
 Run 'pre-commit install' if you want to run on commit
 
@@ -113,6 +90,6 @@ To test before commit run:
 
 A short list of style guidance:
 
-- Headings should be in sentence case
-- Contact Details should be service level contact details
-- Spellchecking should be employed
+* Headings should be in sentence case
+* Contact Details should be service level contact details
+* Spellchecking should be employed


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

```console
$ pre-commit run --all-files
check for added large files..............................................Passed
check for case conflicts.................................................Passed
check json...........................................(no files to check)Skipped
check for merge conflicts................................................Passed
check yaml...............................................................Passed
detect private key.......................................................Passed
fix end of files.........................................................Passed
mixed line ending........................................................Passed
trim trailing whitespace.................................................Failed
- hook id: trailing-whitespace
- exit code: 1
- files were modified by this hook

Fixing CONTRIBUTING.md

don't commit to branch...................................................Passed
fix requirements.txt.....................................................Passed
Check markdown files.....................................................Failed
- hook id: markdownlint
- exit code: 1

...

CONTRIBUTING.md:7: MD029 Ordered list item prefix
CONTRIBUTING.md:10: MD029 Ordered list item prefix
CONTRIBUTING.md:12: MD029 Ordered list item prefix
CONTRIBUTING.md:13: MD029 Ordered list item prefix
CONTRIBUTING.md:14: MD029 Ordered list item prefix
CONTRIBUTING.md:80: MD032 Lists should be surrounded by blank lines
```
This is my fault arising from pull request #231 (I wasn't aware that 'pre-commit' applied to this file too!)

Fixes #232

## Type of change

- [x] Formatting

## What has to be reviewed

List the pages/sections that are to be reviewed.

```
CONTRIBUTING.md
```

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed