### PR TITLE
Adding CES access instructions to TRE user docs

### DIFF
--- a/docs/safe-haven-services/tre-container-user-guide/introduction.md
+++ b/docs/safe-haven-services/tre-container-user-guide/introduction.md
@@ -23,6 +23,9 @@ The development process includes the following steps:
 
 This guide contains a number of [workflow examples](./workflow-examples.md) designed to assist users in building TRE-ready containers. Other [container examples](./container-examples.md) are also available in our [TRE Container Samples](https://github.com/EPCCed/tre-container-samples/) repository.
 
+> [!NOTE]
+> Users wishing to gain access to the CES inside a Safe Haven will need to contact their Research Coordinator and request for access.
+
 ## TRE directories
 
 Before continuing with this guide, it is important that the users are aware of the TRE file system directories so that they can be used correctly within their containers. Project data inside the TRE can be found in the `/safe_data/<project-id>` directory.

--- a/docs/safe-haven-services/tre-container-user-guide/introduction.md
+++ b/docs/safe-haven-services/tre-container-user-guide/introduction.md
@@ -24,7 +24,7 @@ The development process includes the following steps:
 This guide contains a number of [workflow examples](./workflow-examples.md) designed to assist users in building TRE-ready containers. Other [container examples](./container-examples.md) are also available in our [TRE Container Samples](https://github.com/EPCCed/tre-container-samples/) repository.
 
 > [!NOTE]
-> Users wishing to gain access to the CES inside a Safe Haven will need to contact their Research Coordinator and request for access.
+> Users wishing to gain access to the CES inside a Safe Haven will need to contact their Research Coordinator and request access.
 
 ## TRE directories
 


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Adding CES access instructions to TRE user docs to introduction.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Incomplete Documentation

## What has to be reviewed
safe-haven-services -> tre-container-user-guide -> introduction.md

List the pages/sections that are to be reviewed.

## Checklist

- [X] Documentation follows the project style guidelines
- [X] Ensure Contact details contain Service Emails and Numbers
- [X] Self-review of documentation using mkdocs on local system
- [X] Spellcheck has been performed
- [X] Pre-commit has been run and passed
