### PR TITLE
Updated description of how Open OnDemand copies jobs to back-ends

### DIFF
--- a/docs/safe-haven-services/open-ondemand/getting-started.md
+++ b/docs/safe-haven-services/open-ondemand/getting-started.md
@@ -20,11 +20,11 @@ Every time a job is created by an app, Open OnDemand creates the job files the a
 
 For most back-ends, your home directory is common to both the Open OnDemand VM and the back-ends so your directories and files on the Open OnDemand VM, and changes to these, are reflected on the back-ends and vice-versa.
 
-However, you may have access to back-ends where your home directory is not common to both the Open OnDemand VM and the back-end i.e., you have unsynchronised, separate, home directories on each VM. To use such back-ends, you need to do some set up to allow Open OnDemand to automatically copy your `ondemand` directory, and so your job files, to the back-end when you submit a job.
+However, you may have access to back-ends where your home directory is not common to both the Open OnDemand VM and the back-end i.e., you have unsynchronised, separate, home directories on each VM. To use such back-ends, you need to do some set up to allow Open OnDemand to automatically copy job files from within your `ondemand` directory to your chosen back-end when you submit a job.
 
 For the back-ends used by this walkthrough this **only** needs to be done by users of the **DataLoch safe haven**. Users of **other safe havens** can **skip to the next section**, [Run the Run Batch Container app](#run-the-run-batch-container-app) below.
 
-To use a DataLoch VM to run Open OnDemand apps, please follow the instructions in [Enable copy of `ondemand` directory to a back-end](jobs.md#enable-automated-copy-of-ondemand-directory-to-a-back-end) to enable this for the 'desktop' VM on which you are running the browser in which you are using Open OnDemand, then return to this page.
+To use a DataLoch VM to run Open OnDemand apps, please follow the instructions in [Enable automated copy of job files to a back-end](jobs.md#enable-automated-copy-of-job-files-to-a-back-end) to enable this for the 'desktop' VM on which you are running the browser in which you are using Open OnDemand, then return to this page.
 
 ---
 
@@ -460,7 +460,7 @@ hello-from-outputs-to-jupyterlab.txt
 
 Hopefully, this demonstrates how the mounted directories provides a means for data, configuration files, scripts and code to be shared between the back-end on which the container is running and the environment within the container itself.
 
-As a reminder, `safe_outputs/jupyter/SESSION_ID` will persist after the job which created the container ends but the `SESSION_ID` subfolder in `scratch/jupyter` will be deleted.
+As a reminder, `safe_outputs/jupyter/SESSION_ID` will persist after the job which created the container ends but the `SESSION_ID` subdirectory in `scratch/jupyter` will be deleted.
 
 ### Revisit the Active Jobs app
 

--- a/docs/safe-haven-services/open-ondemand/jobs.md
+++ b/docs/safe-haven-services/open-ondemand/jobs.md
@@ -152,13 +152,13 @@ Currently, the back-ends where home directories are not common to both the Open 
 * Superdome Flex, shs-sdf01.nsh.loc.
 * All DataLoch VMs.
 
-To use such back-ends, you need to do some set up to allow Open OnDemand to automatically copy your `ondemand` directory, and so your job files, to the back-end when you submit a job. How to enable this is described in the following section on [Enable copy of `ondemand` directory to a back-end](#enable-automated-copy-of-ondemand-directory-to-a-back-end).
+To use such back-ends, you need to do some set up to allow Open OnDemand to automatically copy job files from within your `ondemand` directory to your chosen back-end when you submit a job. How to enable this is described in the following section on [Enable automated copy of job files to a back-end](#enable-automated-copy-of-job-files-to-a-back-end).
 
-You will also have to log into these back-end to view files created on these back-ends when you run jobs - see [Log into back-ends](ssh.md)
+You will also have to log into your chosen back-end to view files created on these back-ends when you run jobs - see [Log into back-ends](ssh.md)
 
-### Enable automated copy of `ondemand` directory to a back-end
+### Enable automated copy of job files to a back-end
 
-To enable Open OnDemand to automatically copy your `ondemand` directory to a back-end where your home directory is not common to both the Open OnDemand VM and the back-end, you need to set up a passphrase-less SSH key between the Open OnDemand VM and the back-end.
+To enable Open OnDemand to automatically copy job files from within your `ondemand` directory to a back-end where your home directory is not common to both the Open OnDemand VM and the back-end, you need to set up a passphrase-less SSH key between the Open OnDemand VM and the back-end.
 
 !!! Note
 
@@ -235,7 +235,7 @@ Briefly, when a job is submitted, the following occurs:
 
 1. Open OnDemand submits the job to the job scheduler to run the job on your chosen back-end.
     * A job scheduler preprocessing step is used to create a log file in an `ondemand/logs/slurm` directory.
-    * For back-ends where your home directory is not common to both both the Open OnDemand VM and the back-end, a job scheduler preprocessing step automatically copies your `ondemand` directory to the back-end.
+    * For back-ends where your home directory is not common to both both the Open OnDemand VM and the back-end, a job scheduler preprocessing step automatically copies your job files from within your `ondemand` directory to the back-end. The relative directory structure from the `ondemand` directory to the job files directory is preserved by the copy.
 1. The job scheduler queues your job, pending processing and memory resources on the back-end becoming available. The job status will be 'Queued'.
 1. When resources become available on the back-end, your job runs:
     * For jobs created via the [Job Composer](apps/job-composer.md) app, the job status will be 'Running'.


### PR DESCRIPTION

# EIDF Documentation Pull Request

## Description

For back-ends with unsynchronised home directories, the 'ondemand' directory is no longer copied as-is. Instead, the copy copies the job files in their job folder and preserves the relative path from the 'ondemand' job folder i.e., only the files needed for a specific job are copied, not the entire contents of 'ondemand'

## Type of change

- [x] Incorrect Documentation

## What has to be reviewed

```text
docs/safe-haven-services/open-ondemand/jobs.md
docs/safe-haven-services/open-ondemand/getting-started.md
```

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
