### PR TITLE
Open OnDemand cluster names no longer include 'tenant' in their short-name

### DIFF
--- a/docs/safe-haven-services/open-ondemand/apps/batch-container-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/batch-container-app.md
@@ -10,7 +10,7 @@ Containers run **must** conform to the [Container requirements](../containers.md
 
 Complete the following information the app form:
 
-* **Cluster**: A back-end (cluster) within your safe haven on which to run the container. Back-end-specific  short-names are used in the drop-down list, and safe haven-specific back-ends include the text 'tenant', to distinguish them from any TRE-level back-ends to which you might have access (see [Back-end (cluster) names](../jobs.md#back-end-cluster-names) for more information).
+* **Cluster**: A back-end (cluster) within your safe haven on which to run the container. Back-end-specific short-names are used in the drop-down list (see [Back-end (cluster) names](../jobs.md#back-end-cluster-names) for more information). If there is only one back-end available to you then this form field won't be shown.
 
     !!! Note
 

--- a/docs/safe-haven-services/open-ondemand/apps/jupyter-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/jupyter-app.md
@@ -10,7 +10,7 @@ The container is run using Podman.
 
 Complete the following information the app form:
 
-* **Cluster**: A back-end (cluster) within your safe haven on which to run the container. Back-end-specific  short-names are used in the drop-down list, and safe haven-specific back-ends include the text 'tenant', to distinguish them from any TRE-level back-ends to which you might have access (see [Back-end (cluster) names](../jobs.md#back-end-cluster-names) for more information).
+* **Cluster**: A back-end (cluster) within your safe haven on which to run the container. Back-end-specific short-names are used in the drop-down list (see [Back-end (cluster) names](../jobs.md#back-end-cluster-names) for more information). If there is only one back-end available to you then this form field won't be shown.
 
     !!! Note
 

--- a/docs/safe-haven-services/open-ondemand/apps/rstudio-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/rstudio-app.md
@@ -10,7 +10,7 @@ The container is run using Podman.
 
 Complete the following information the app form:
 
-* **Cluster**: A back-end (cluster) within your safe haven on which to run the container. Back-end-specific  short-names are used in the drop-down list, and safe haven-specific back-ends include the text 'tenant', to distinguish them from any TRE-level back-ends to which you might have access (see [Back-end (cluster) names](../jobs.md#back-end-cluster-names) for more information).
+* **Cluster**: A back-end (cluster) within your safe haven on which to run the container. Back-end-specific short-names are used in the drop-down list (see [Back-end (cluster) names](../jobs.md#back-end-cluster-names) for more information). If there is only one back-end available to you then this form field won't be shown.
 
     !!! Note
 

--- a/docs/safe-haven-services/open-ondemand/getting-started.md
+++ b/docs/safe-haven-services/open-ondemand/getting-started.md
@@ -45,7 +45,7 @@ The app form is prepopulated with the configuration to pull and run a 'hello TRE
 
 Read the form entries in conjunction with the explanations below and make the suggested changes:
 
-* **Cluster** selects a back-end (cluster) within your safe haven on which to run the container. Back-end-specific short-names are used in the drop-down list, and safe haven-specific back-ends include the text 'tenant', to distinguish them from any TRE-level back-ends to which you might have access.
+* **Cluster**: A back-end (cluster) within your safe haven on which to run the container. Back-end-specific short-names are used in the drop-down list. If there is only one back-end available to you then this form field won't be shown.
     * Select the 'desktop' VM on which you are running the browser in which you are using Open OnDemand.
 * **Container/image URL in container registry** cites a URL specifying both the container to run and the container registry from which it is to be pulled.
     * Leave this value as-is to use the `ghcr.io/mikej888/hello-tre:1.0` container, hereon termed `hello-tre`.
@@ -325,7 +325,7 @@ The Run JupyterLab Container app form will open.
 
 This app's form has far less settings since it is designed to run, using Podman, a JupyterLab container created for use with the TRE Container Execution Service.
 
-For **Cluster**, select the 'desktop' VM on which you are running the browser in which you are using Open OnDemand.
+For **Cluster**, select the 'desktop' VM on which you are running the browser in which you are using Open OnDemand. If there is only one back-end available to you then this form field won't be shown.
 
 Leave the other settings as-is.
 

--- a/docs/safe-haven-services/open-ondemand/jobs.md
+++ b/docs/safe-haven-services/open-ondemand/jobs.md
@@ -40,19 +40,15 @@ Within Open OnDemand, back-ends are typically referred to via human-readable nam
 
 A convention is adopted whereby safe haven-specific back-ends always cite the safe haven name.
 
-Within some interactive apps, you will see back-ends referred to via 'short-names'. Typically, these short-names are derived from the back-ends' VM names. However, a convention is adopted whereby safe haven-specific back-ends include the text 'tenant', to distinguish them from any TRE-level back-ends to which you might have access. So, for example, the short-names corresponding to the above back-ends are:
+Within some interactive apps, you will see back-ends referred to via 'short-names'. Typically, these short-names are derived from the back-ends' VM names. So, for example, the short-names corresponding to the above back-ends are:
 
-* dap_tenant_1234_5678
-* nsh_tenant_gpu_desktop01
-* odp_tenant_gpu_desktop01
-* smartdf_tenant_gpu_desktop01
-* shs_sdf01 - as the Superdome Flex is a TRE-level, not safe haven-specific, back-end its short-name does not include 'tenant'.
+* dap_1234_5678
+* nsh_gpu_desktop01
+* odp_gpu_desktop01
+* smartdf_gpu_desktop01
+* shs_sdf01
 
 Within [job cards](#job-cards) on the [My Interactive Sessions](#my-interactive-sessions-page) page, described below, you will see the VM names upon which the jobs are running.
-
-!!! Info
-
-    The use of 'tenant' in short-names is adopted as a means to exploit Open OnDemand's use of filters to constrain certain apps to only be applicable to certain back-ends.
 
 ---
 
@@ -327,7 +323,7 @@ Click **Delete** on a job card to delete the job card.
 
 When a job is submitted to a back-end, a log file is created within an `ondemand/logs/slurm` directory within your home directory on the Open OnDemand VM.
 
-Log files have name `sbatch-YYYYMMDD-HHMMSS_OPEN_ONDEMAND_CLUSTER_NAME`. For example, `sbatch-20240807-082901-nsh_tenant_gpu_desktop01`.
+Log files have name `sbatch-YYYYMMDD-HHMMSS_OPEN_ONDEMAND_CLUSTER_NAME`. For example, `sbatch-20240807-082901-nsh_gpu_desktop01`.
 
 An example of the contents of a log file is as follows:
 


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Open OnDemand cluster names no longer include 'tenant' in their short-name

## Type of change

- [x] Incorrect Documentation

## What has to be reviewed

```
docs/safe-haven-services/open-ondemand/apps/batch-container-app.md
docs/safe-haven-services/open-ondemand/apps/jupyter-app.md
docs/safe-haven-services/open-ondemand/apps/rstudio-app.md
docs/safe-haven-services/open-ondemand/getting-started.md
docs/safe-haven-services/open-ondemand/jobs.md
```

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
