### PR TITLE
Clarified use of public vs. private repositories and access tokens when using CES and GHCR

### DIFF
--- a/docs/safe-haven-services/open-ondemand/apps.md
+++ b/docs/safe-haven-services/open-ondemand/apps.md
@@ -26,9 +26,9 @@ In each case, selecting an app will open an app-specific page, from which you ca
 
 ---
 
-## Open OnDemand home page
+## Jobs panel
 
-The Open OnDemand home page has a **selection** of the apps available to you.
+The Jobs panel on the Open OnDemand home page has a **selection** of the apps available to you.
 
 Click on an app button to access that app.
 
@@ -38,7 +38,7 @@ Click on an app button to access that app.
 
 The Apps menu provides access to **all** of the apps available to you.
 
-Select an app-specific menu option to access that app. The app-specific menu options correspond to apps available on the Open OnDemand home page.
+Select an app-specific menu option to access that app. The app-specific menu options correspond to the apps available via the Jobs panel.
 
 To see all of the apps available to you, select the **All Apps** option to go to the All Apps page.
 


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

At present, the TRE CES user documentation implies that only private GHCR repositories can be used. Users of the TRE container execution service 'ces-tools' can use either public or private GHCR repositories. However, when using 'ces-tools' they must provide both a username and an access token.

Updated `docs/safe-haven-services/tre-container-user-guide/*md`:

* Removed any mention of 'private' repositories.
* Stated that 'ces-pull' username/namespace and token arguments are mandatory.
* Clarified that, for pushing containers, a GitHub access token with 'repo' and 'write:packages' scopes is required.
* Clarified that, for pulling containers within the test environment or the TRE, a GitHub access token with 'read:packages' scopes is recommended to keep the user's GHCR secure.
* For pulling containers, a read-only access token (not a password or read-write access token) is recommended.

Fixes #266 

## Type of change

- [x] Incorrect Documentation
- [x] Incomplete Documentation

## What has to be reviewed

```text
docs/safe-haven-services/tre-container-user-guide/development-workflow.md
docs/safe-haven-services/tre-container-user-guide/workflow-examples.md
docs/safe-haven-services/tre-container-user-guide/introduction.md # Note, fixed typo only
```

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
