### PR TITLE
Open OnDemand deployments no longer has a 'Jobs' menu

### DIFF
--- a/docs/safe-haven-services/open-ondemand/apps.md
+++ b/docs/safe-haven-services/open-ondemand/apps.md
@@ -44,18 +44,6 @@ To see all of the apps available to you, select the **All Apps** option to go to
 
 ---
 
-## **Jobs** menu
-
-The **Jobs** menu shows **all** of the apps available to you.
-
-Select an app-specific menu option to access that app.
-
-!!! Info
-
-    If you are wondering why the **Apps** menu and **Jobs** menu overlap, this is because each app has a 'category' label. This is used by Open OnDemand both to group app buttons on the home page and to create menus with apps belonging to a specific category. All Container Execution Service apps are within a 'Jobs' category, hence the overlap.
-
----
-
 ## All Apps page
 
 Select the **Apps** menu, **All Apps** option to go to the All Apps page.


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Open OnDemand deployments no longer has a 'Jobs' menu. This reduced menubar clutter to remove this menu. All apps are available via the 'Apps' menu anyway.

Updated `docs/safe-haven-services/open-ondemand/apps.md` to remove the `**Jobs** menu` section.

Fixes #271

## Type of change

Please delete options that are not relevant.

- [x] Incorrect Documentation

## What has to be reviewed

`docs/safe-haven-services/open-ondemand/apps.md`

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
