### PR TITLE
Open OnDemand apps no longer grouped by category on front page

### DIFF
--- a/docs/safe-haven-services/open-ondemand/apps.md
+++ b/docs/safe-haven-services/open-ondemand/apps.md
@@ -26,9 +26,9 @@ In each case, selecting an app will open an app-specific page, from which you ca
 
 ---
 
-## Jobs panel
+## Open OnDemand home page
 
-The Jobs panel on the Open OnDemand home page has a **selection** of the apps available to you.
+The Open OnDemand home page has a **selection** of the apps available to you.
 
 Click on an app button to access that app.
 
@@ -38,7 +38,7 @@ Click on an app button to access that app.
 
 The Apps menu provides access to **all** of the apps available to you.
 
-Select an app-specific menu option to access that app. The app-specific menu options correspond to the apps available via the Jobs panel.
+Select an app-specific menu option to access that app. The app-specific menu options correspond to apps available on the Open OnDemand home page.
 
 To see all of the apps available to you, select the **All Apps** option to go to the All Apps page.
 


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Open OnDemand apps no longer grouped by category on front page

Fixes #273 (issue)

## Type of change

Please delete options that are not relevant.

- [x] Incorrect Documentation

## What has to be reviewed

`docs/safe-haven-services/open-ondemand/apps.md`

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
