### PR TITLE
Clarify OOD Job Composer and Active Jobs job names

### DIFF
--- a/docs/safe-haven-services/open-ondemand/apps/active-jobs.md
+++ b/docs/safe-haven-services/open-ondemand/apps/active-jobs.md
@@ -8,9 +8,15 @@ The Active Jobs app shows a table of running and recently completed jobs.
 
 ## Jobs table
 
+The job name is a job name set when the job is created and used by the job scheduler. Job names are app-specific and job scheduler-specific.
+
 The job ID is a unique job ID created by the job scheduler, when you submitted the job.
 
 ![Active Jobs app jobs table](../../../images/open-ondemand/active-jobs.png){: class="border-img center"} *The Active Jobs app job table*
+
+!!! Note
+
+    The job name is an app-specific job scheduler-specific job name. For the Job Composer and Slurm, the job name is the value of the Slurm `--job-name` parameter (set by `#SBATCH --job-name=...` in the job file). This job name is not the same as the job name shown in the Jobs table is used by the Job Composer. That job name is one entered in the **Job Name** field when completing the Job Composer's job submission forms.
 
 !!! Note
 

--- a/docs/safe-haven-services/open-ondemand/apps/job-composer.md
+++ b/docs/safe-haven-services/open-ondemand/apps/job-composer.md
@@ -4,7 +4,7 @@ Job Composer is an app that allows you to write and submit a Slurm batch job to 
 
 !!! Note
 
-    To use the Job Composer app requires you to have some familiarity with the [Slurm](https://slurm.schedmd.com) open source job scheduler and workload manager. In particular, how to write Slurm job submission files.
+    To use the Job Composer requires you to have some familiarity with the [Slurm](https://slurm.schedmd.com) open source job scheduler and workload manager. In particular, how to write Slurm job submission files.
 
 ---
 
@@ -73,6 +73,12 @@ Click **Submit job** (green play icon) to submit your job.
 ## Browse and manage jobs
 
 ### Jobs table
+
+The job name is the name of the job you specified when completing the [Create Slurm job](#create-slurm-job) form.
+
+!!! Note
+
+    The job name shown in the Jobs table is one entered in the **Job Name** when completing the Job Composer's job submission forms. This job name is not the same as the job name shown in the [Active Jobs](./active-jobs.md) app. That job name is an app-specific job scheduler-specific job name. For the Job Composer and Slurm, the Active Jobs job name is the value of the Slurm `--job-name` parameter (set by `#SBATCH --job-name=...` in the job file).
 
 The job ID is a unique job ID created by the Slurm job scheduler, when you submitted the job.
 


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Clarified difference between Open OnDemand Job Composer and Active Jobs/job scheduler job names. The former are chosen by the user and are specific to the Job Composer only. The latter are those used by Slurm and are app-specific.

## Type of change

- [x] Missing Documentation

## What has to be reviewed

```text
docs/safe-haven-services/open-ondemand/apps/active-jobs.md
docs/safe-haven-services/open-ondemand/apps/job-composer.md
```

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
