### PR TITLE
Updated OOD JupyterLab/RStudio Server docs to reflect form updates

### DIFF
--- a/docs/safe-haven-services/open-ondemand/apps/jupyter-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/jupyter-app.md
@@ -14,7 +14,6 @@ Complete the following information the app form:
 
         **National Safe Haven users**: If using a 'desktop' back-end, then you must select the 'desktop' you have been granted access to.
 
-* **Container name**: Name to be given to the container when it is run. Your job will fail if there is already a running container with that name. If omitted, then the default is `epcc-ces-jupyter-SESSION_ID`, where `SESSION_ID` is a unique session identifier for the app's job.
 * **Cores**: Number of cores/CPUs requested for this job. Your selected back-end must have at least that number of cores/CPUs request.
 * **Memory in GiB**: Memory requested for this job. Your selected back-end must have at least that amount of memory available.
 
@@ -35,7 +34,7 @@ Open OnDemand will show an app job card with information about the app's job inc
 
 When the job starts, the Job status on the job card will update to 'Starting' and 'Time Requested' will switch to 'Time Remaining', the time your job has left to run before it is cancelled by the job scheduler.
 
-When the Job status updates to 'Running', a **Host** link will appear on the job card, which allows you to log in to the back-end on which the job, and so the JupyterLab container, is now running. A 'JupyterLab is running in Podman container CONTAINER_NAME' message will appear along with a **Connect to JupyterLab** button. The JupyterLab container is now ready for use.
+When the Job status updates to 'Running', a **Host** link will appear on the job card, which allows you to log in to the back-end on which the job, and so the JupyterLab container, is now running. A 'JupyterLab is running in Podman container epcc-ces-jupyter-SESSION_ID' message will appear along with a **Connect to JupyterLab** button. The JupyterLab container is now ready for use.
 
 Click **Connect to JupyterLab**. A new browser tab will open with JupyterLab.
 

--- a/docs/safe-haven-services/open-ondemand/apps/rstudio-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/rstudio-app.md
@@ -14,7 +14,6 @@ Complete the following information the app form:
 
         **National Safe Haven users**: If using a 'desktop' back-end, then you must select the 'desktop' you have been granted access to.
 
-* **Container name**: Name to be given to the container when it is run. Your job will fail if there is already a running container with that name. If omitted, then the default is `epcc-ces-rstudio-SESSION_ID`, where `SESSION_ID` is a unique session identifier for the app's job.
 * **RStudio Server password**: RStudio Server running in the container needs to be password-protected. Specify the password to use.
 * **Cores**: Number of cores/CPUs requested for this job. Your selected back-end must have at least that number of cores/CPUs request.
 * **Memory in GiB**: Memory requested for this job. Your selected back-end must have at least that amount of memory available.
@@ -36,7 +35,7 @@ Open OnDemand will show an app job card with information about the app's job inc
 
 When the job starts, the Job status on the job card will update to 'Starting' and 'Time Requested' will switch to 'Time Remaining', the time your job has left to run before it is cancelled by the job scheduler.
 
-When the Job status updates to 'Running', a **Host** link will appear on the job card, which allows you to log in to the back-end on which the job, and so the RStudio Server container, is now running. A 'RStudio Server is running in Podman container CONTAINER_NAME' message will appear along with a **Connect to RStudio Server** button. The RStudio Server container is now ready for use.
+When the Job status updates to 'Running', a **Host** link will appear on the job card, which allows you to log in to the back-end on which the job, and so the RStudio Server container, is now running. A 'RStudio Server is running in Podman container epcc-ces-rstudio-SESSION_ID' message will appear along with a **Connect to RStudio Server** button. The RStudio Server container is now ready for use.
 
 Click **Connect to RStudio Server**. A new browser tab will open with RStudio Server.
 

--- a/docs/safe-haven-services/open-ondemand/getting-started.md
+++ b/docs/safe-haven-services/open-ondemand/getting-started.md
@@ -347,7 +347,6 @@ Again, Open OnDemand will show an app job card with information about the app's 
 * 'Time Requested': The runtime requested for the job which defaults to 6 hours.
 * 'Session ID': An auto-generated value which is used as the name of the job-specific job context directory. This is a link to open a File Manager pointing at the job context directory.
 * App-specific information, which includes values from the app form:
-    * 'Container name'
     * 'Connection timeout': when the app's job starts running, the app will then wait for JupyterLab to become available within the container. If this does not occur within this app-specific period (180 seconds i.e., 3 minutes), then the app's job will cancel itself.
     * 'Cores'
     * 'Memory in GiB'


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

'container_name' is no longer a user-selectable option.

## Type of change

- [x] Incorrect Documentation

## What has to be reviewed

```text
docs/safe-haven-services/open-ondemand/getting-started.md
docs/safe-haven-services/open-ondemand/apps/jupyter-app.md
docs/safe-haven-services/open-ondemand/apps/rstudio-app.md
```

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
