### PR TITLE
Rewrote OOD app documentation for clarity and consistency

### DIFF
--- a/docs/safe-haven-services/open-ondemand/apps/batch-container-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/batch-container-app.md
@@ -64,11 +64,11 @@ When the Job status updates to 'Running', a **Host** link will appear on the job
 
 !!! Warning
 
-    Your job, and so your container. will run for a maximum of 6 hours, after which it will be cancelled.
+    Your job will run for a maximum of 6 hours, after which it will be cancelled.
 
 !!! Warning
 
-    Any running jobs, and containers, will be cancelled during the monthly TRE maintenance period.
+    Any running jobs are cancelled during the monthly TRE maintenance period.
 
 !!! Note
 
@@ -178,7 +178,7 @@ If the job has completed, see [Log into back-ends](../ssh.md) for ways to log in
 
 ## Take a break
 
-Your container job will continue to run even if you do the following:
+Your container will continue to run even if you do the following:
 
 * Close the browser tab.
 * Log out of Open OnDemand.

--- a/docs/safe-haven-services/open-ondemand/apps/job-composer.md
+++ b/docs/safe-haven-services/open-ondemand/apps/job-composer.md
@@ -66,7 +66,7 @@ Click **Submit job** (green play icon) to submit your job.
 
 !!! Warning
 
-    Any running jobs will be cancelled during the monthly TRE maintenance period.
+    Any running jobs are cancelled during the monthly TRE maintenance period.
 
 ---
 

--- a/docs/safe-haven-services/open-ondemand/apps/jupyter-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/jupyter-app.md
@@ -1,6 +1,6 @@
 # Run JupyterLab Container
 
-Run JupyterLab Container is an app that runs a JupyterLab container on a back-end within your safe haven. The JupyterLab container was built for the TRE Open OnDemand service. The container is run using Podman.
+Run JupyterLab Container is an app that runs JupyterLab on a back-end within your safe haven. JupyterLab is run as a container, using Podman.
 
 ---
 
@@ -8,7 +8,7 @@ Run JupyterLab Container is an app that runs a JupyterLab container on a back-en
 
 Complete the following information the app form:
 
-* **Cluster**: A back-end (cluster) within your safe haven on which to run the container. Back-end-specific short-names are used in the drop-down list (see [Back-end (cluster) names](../jobs.md#back-end-cluster-names) for more information). If there is only one back-end available to you then this form field won't be shown.
+* **Cluster**: A back-end (cluster) within your safe haven on which to run JupyterLab. Back-end-specific short-names are used in the drop-down list (see [Back-end (cluster) names](../jobs.md#back-end-cluster-names) for more information). If there is only one back-end available to you then this form field won't be shown.
 
     !!! Note
 
@@ -34,21 +34,25 @@ Open OnDemand will show an app job card with information about the app's job inc
 
 When the job starts, the Job status on the job card will update to 'Starting' and 'Time Requested' will switch to 'Time Remaining', the time your job has left to run before it is cancelled by the job scheduler.
 
-When the Job status updates to 'Running', a **Host** link will appear on the job card, which allows you to log in to the back-end on which the job, and so the JupyterLab container, is now running. A 'JupyterLab is running in Podman container epcc-ces-jupyter-SESSION_ID' message will appear along with a **Connect to JupyterLab** button. The JupyterLab container is now ready for use.
+When the Job status updates to 'Running', a **Host** link will appear on the job card, which allows you to log in to the back-end on which the job, and so JupyterLab, is now running.
+
+A **Connect to JupyterLab** button will appear. JupyterLab is now ready for use.
+
+A 'JupyterLab is running in Podman container epcc-ces-jupyter-SESSION_ID' message will also appear.
 
 Click **Connect to JupyterLab**. A new browser tab will open with JupyterLab.
 
 !!! Warning
 
-    Open OnDemand will wait 180 seconds (3 minutes) for your container to start. If it does not start within this time the job will be cancelled.
+    Open OnDemand will wait 180 seconds (3 minutes) for JupyterLab to start. If it does not start within this time the job will be cancelled.
 
 !!! Warning
 
-    Your job, and so your container. will run for a maximum of 6 hours.
+    JupyterLab will run for a maximum of 6 hours, after which it will be cancelled.
 
 !!! Warning
 
-    Any running jobs, and containers, will be cancelled during the monthly TRE maintenance period.
+    Any running jobs are cancelled during the monthly TRE maintenance period.
 
 !!! Note
 
@@ -58,25 +62,27 @@ Click **Connect to JupyterLab**. A new browser tab will open with JupyterLab.
 
 ## Log in to JupyterLab
 
-You will not be prompted for a username and password. JupyterLab running in the container runs as a 'root' user. JupyterLab is protected with an auto-generated password. The **Connect to JupyterLab** button is configured to log you into the container using this password automatically.
+You will not be prompted for a username and password. JupyterLab is protected with an auto-generated password and **Connect to JupyterLab** button is configured to log you in automatically using this password.
+
+Within JupyterLab you are the 'root' user.
 
 !!! Note
 
-    You are the 'root' user **only** within the context of the container. You will not have 'root' access to the back-end on which the container is running! Any files you create in the directories mounted into the container will be owned by your own user, and user group, on the back-end.
+    You are the 'root' user **only** within the context of the JupyterLab container. You will not have 'root' access to the back-end on which the container is running! Any files you create in the directories mounted into the container will be owned by your own user, and user group, on the back-end.
 
 ---
 
-## Sharing files between the back-end and the container and persisting state between app runs
+## Sharing files between the back-end and JupyterLab and persisting state between app runs
 
-The app mounts three directories from the back-end into the container at `/safe_data`, `/safe_outputs` and `.scratch` . For information on what these directories can be used for, see [Sharing files between a back-end and a container](../containers.md#sharing-files-between-a-back-end-and-a-container).
+The app mounts three directories from the back-end into JupyterLab at `/safe_data`, `/safe_outputs` and `.scratch` . For information on what these directories can be used for, see [Sharing files between a back-end and a container](../containers.md#sharing-files-between-a-back-end-and-a-container).
 
-The app also creates a `$HOME/.local/share/ondemand/apps/jupyter_app/` in your home directory on the back-end and nounts this into the container at `/mnt/jupyter_host`. If you create virtual environments and/or install Python packages into `/mnt/jupyter_host` when using JupyterLab, then these will be available to you when you run the app in future (each run of the app creates a new container, and this mount allows for state to be persisted between runs).
+The app also creates a `$HOME/.local/share/ondemand/apps/jupyter_app/` in your home directory on the back-end and nounts this into JupyterLab at `/mnt/jupyter_host`. If you create virtual environments and/or install Python packages into `/mnt/jupyter_host` when using JupyterLab, then these will be available to you when you run the app in future (each run of the app creates a new container, and this mount allows for state to be persisted between runs).
 
 ---
 
 ## Installing Python packages
 
-The container is configured with your web proxy environment variables so you can install packages from PyPI when using JupyterLab. It is recommended that you create virtual environments and/or install Python packages into `/mnt/jupyter_host` so that you can reuse these the next time you run your container.
+JupyterLab is configured with your web proxy environment variables so you can install packages from PyPI when using JupyterLab. It is recommended that you create virtual environments and/or install Python packages into `/mnt/jupyter_host` so that you can reuse these the next time you run the app on the same back-end.
 
 ---
 
@@ -100,14 +106,14 @@ If the job has completed, see [Log into back-ends](../ssh.md) for ways to log in
 
 ## Take a break
 
-Your container job will continue to run even if you do the following:
+JupyterLab will continue to run even if you do the following:
 
 * Log out of JupyterLab via the **File** menu, **Log Out** option.
 * Close the browser tab.
 * Log out of Open OnDemand.
 * Log out of the VM from which you accessed Open OnDemand.
 
-You can re-access your running container via the **Connect to JupyterLab** on your session's [job card](../jobs.md#job-cards) on the [My Interactive Sessions](../jobs.md#my-interactive-sessions-page) page accessed via **My Interactive Sessions** (overlaid squares icon) on the menu bar.
+You can re-access your running JupyterLab via the **Connect to JupyterLab** on your session's [job card](../jobs.md#job-cards) on the [My Interactive Sessions](../jobs.md#my-interactive-sessions-page) page accessed via **My Interactive Sessions** (overlaid squares icon) on the menu bar.
 
 ![My Interactive Sessions menu button, an overlaid squares icon](../../../images/open-ondemand/my-interactive-sessions-button.png){: class="border-img center"} ***My Interactive Sessions** menu button*
 

--- a/docs/safe-haven-services/open-ondemand/apps/rstudio-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/rstudio-app.md
@@ -1,6 +1,6 @@
 # Run RStudio Server Container
 
-Run RStudio Server Container is an app that runs an RStudio Server container on a back-end within your safe haven. The RStudio Server container was built for the TRE Open OnDemand service. The container is run using Podman.
+Run RStudio Server Container is an app that runs RStudio Server on a back-end within your safe haven. RStudio Server is run as a container, using Podman.
 
 ---
 
@@ -8,7 +8,7 @@ Run RStudio Server Container is an app that runs an RStudio Server container on 
 
 Complete the following information the app form:
 
-* **Cluster**: A back-end (cluster) within your safe haven on which to run the container. Back-end-specific short-names are used in the drop-down list (see [Back-end (cluster) names](../jobs.md#back-end-cluster-names) for more information). If there is only one back-end available to you then this form field won't be shown.
+* **Cluster**: A back-end (cluster) within your safe haven on which to run RStudio Server. Back-end-specific short-names are used in the drop-down list (see [Back-end (cluster) names](../jobs.md#back-end-cluster-names) for more information). If there is only one back-end available to you then this form field won't be shown.
 
     !!! Note
 
@@ -35,21 +35,25 @@ Open OnDemand will show an app job card with information about the app's job inc
 
 When the job starts, the Job status on the job card will update to 'Starting' and 'Time Requested' will switch to 'Time Remaining', the time your job has left to run before it is cancelled by the job scheduler.
 
-When the Job status updates to 'Running', a **Host** link will appear on the job card, which allows you to log in to the back-end on which the job, and so the RStudio Server container, is now running. A 'RStudio Server is running in Podman container epcc-ces-rstudio-SESSION_ID' message will appear along with a **Connect to RStudio Server** button. The RStudio Server container is now ready for use.
+When the Job status updates to 'Running', a **Host** link will appear on the job card, which allows you to log in to the back-end on which the job, and so RStudio Server, is now running.
+
+A **Connect to RStudio Server** button will appear. RStudio Server is now ready for use.
+
+A 'RStudio Server is running in Podman container epcc-ces-rstudio-SESSION_ID' message will also appear.
 
 Click **Connect to RStudio Server**. A new browser tab will open with RStudio Server.
 
 !!! Warning
 
-    Open OnDemand will wait 180 seconds (3 minutes) for your container to start. If it does not start within this time the job will be cancelled.
+    Open OnDemand will wait 180 seconds (3 minutes) for RStudio Server to start. If it does not start within this time the job will be cancelled.
 
 !!! Warning
 
-    Your job, and so your container. will run for a maximum of 6 hours.
+    RStudio Server will run for a maximum of 6 hours, after which it will be cancelled.
 
 !!! Warning
 
-    Any running jobs, and containers, will be cancelled during the monthly TRE maintenance period.
+    Any running jobs are cancelled during the monthly TRE maintenance period.
 
 !!! Note
 
@@ -68,21 +72,21 @@ Click **Sign in**.
 
 !!! Note
 
-    You are the 'root' user **only** within the context of the container. You will not have 'root' access to the back-end on which the container is running! Any files you create in the directories mounted into the container will be owned by your own user, and user group, on the back-end.
+    You are the 'root' user **only** within the context of the RStudio Server container. You will not have 'root' access to the back-end on which the container is running! Any files you create in the directories mounted into the container will be owned by your own user, and user group, on the back-end.
 
 ---
 
-## Sharing files between the back-end and the container and persisting state between app runs
+## Sharing files between the back-end and RStudio Server and persisting state between app runs
 
-The app mounts three directories from the back-end into the container at `/safe_data`, `/safe_outputs` and `.scratch` . For information on what these directories can be used for, see [Sharing files between a back-end and a container](../containers.md#sharing-files-between-a-back-end-and-a-container).
+The app mounts three directories from the back-end into RStudio Server at `/safe_data`, `/safe_outputs` and `.scratch` . For information on what these directories can be used for, see [Sharing files between a back-end and a container](../containers.md#sharing-files-between-a-back-end-and-a-container).
 
-The app also creates a `$HOME/.local/share/ondemand/apps/rstudio_app/` in your home directory on the back-end and nounts this into the container at `/mnt/rstudio_host`. If you create virtual environments and/or install Python packages into `/mnt/rstudio_host` when using RStudio Server, then these will be available to you when you run the app in future (each run of the app creates a new container, and this mount allows for state to be persisted between runs).
+The app also creates a `$HOME/.local/share/ondemand/apps/rstudio_app/` in your home directory on the back-end and nounts this into RStudio Server at `/mnt/rstudio_host`. If you install R packages into `/mnt/rstudio_host` when using RStudio Server, then these will be available to you when you run the app in future (each run of the app creates a new container, and this mount allows for state to be persisted between runs).
 
 ---
 
 ## Installing R packages
 
-The container is configured with your web proxy environment variables so you can install packages from CRAN when using RStudio Server. It is recommended that you create virtual environments and/or install R packages into `/mnt/rstudio_host` so that you can reuse these the next time you run your container.
+RStudio Server is configured with your web proxy environment variables so you can install packages from CRAN when using RStudio Server. It is recommended that you install R packages into `/mnt/rstudio_host` so that you can reuse these the next time you run the app on the same back-end.
 
 ---
 
@@ -106,7 +110,7 @@ If the job has completed, see [Log into back-ends](../ssh.md) for ways to log in
 
 ## Take a break
 
-Your container job will continue to run even if you do the following:
+RStudio Server will continue to run even if you do the following:
 
 * Log out of RStudio Server via the **File** menu, **Sign Out** option.
 * Log out of RStudio Server via the **File** menu, **Quit Session...** option.
@@ -114,7 +118,7 @@ Your container job will continue to run even if you do the following:
 * Log out of Open OnDemand.
 * Log out of the VM from which you accessed Open OnDemand.
 
-You can re-access your running container via the **Connect to RStudio Server** on your session's [job card](../jobs.md#job-cards) on the [My Interactive Sessions](../jobs.md#my-interactive-sessions-page) page accessed via **My Interactive Sessions** (overlaid squares icon) on the menu bar.
+You can re-access your running RStudio Server via the **Connect to RStudio Server** on your session's [job card](../jobs.md#job-cards) on the [My Interactive Sessions](../jobs.md#my-interactive-sessions-page) page accessed via **My Interactive Sessions** (overlaid squares icon) on the menu bar.
 
 ![My Interactive Sessions menu button, an overlaid squares icon](../../../images/open-ondemand/my-interactive-sessions-button.png){: class="border-img center"} ***My Interactive Sessions** menu button*
 

--- a/docs/safe-haven-services/open-ondemand/getting-started.md
+++ b/docs/safe-haven-services/open-ondemand/getting-started.md
@@ -357,17 +357,22 @@ Again, Open OnDemand will show an app job card with information about the app's 
 
 When the job starts, the Job status on the job card will update to 'Starting' and 'Time Requested' will switch to 'Time Remaining', the time your job has left to run before it is cancelled by the job scheduler.
 
-When the Job status updates to 'Running', a **Host** link will appear on the job card, which allows you to log in to the back-end on which the job, and so the JupyterLab container, is now running. A 'JupyterLab is running in Podman container epcc-ces-jupyter-SESSION_ID' message will appear along with a **Connect to JupyterLab** button. The JupyterLab container is now ready for use.
+When the Job status updates to 'Running', a **Host** link will appear on the job card, which allows you to log in to the back-end on which the
+job, and so JupyterLab, is now running.
+
+A **Connect to JupyterLab** button will appear. JupyterLab is now ready for use.
+
+A 'JupyterLab is running in Podman container epcc-ces-jupyter-SESSION_ID' message will also appear.
 
 ![Run JupyterLab Container app job card showing job status as 'Running'](../../images/open-ondemand/getting-started-11-jupyter-app-running.png){: class="border-img center"}
 *Run JupyterLab Container app job card showing job status as 'Running'*
 
 Click **Connect to JupyterLab**. A new browser tab will open with JupyterLab.
 
-You may wonder why you were not prompted for a username and password. JupyterLab running in the container runs as a 'root' user. The 'root' user is within the context of the container only. JupyterLab is protected with an auto-generated password. The **Connect to JupyterLab** button is configured to log you into the container using this password automatically.
+You may wonder why you were not prompted for a username and password. JupyterLab runs within the container as a 'root' user. The 'root' user is within the context of the container **only**. JupyterLab is protected with an auto-generated password. The **Connect to JupyterLab** button is configured to log you into JupyterLab using this password automatically.
 
-![JupyterLab running within a container](../../images/open-ondemand/getting-started-12-jupyter-app-jupyter-lab.png){: class="border-img center"}
-*JupyterLab running within a container*
+![JupyterLab](../../images/open-ondemand/getting-started-12-jupyter-app-jupyter-lab.png){: class="border-img center"}
+*JupyterLab*
 
 ### Use JupyterLab to explore how directories on a back-end are mounted into a container
 
@@ -375,7 +380,7 @@ We can use JupyterLab to further explore how directories on a back-end are mount
 
 Click the **Host** link to log into the back-end on which the job, and JupyterLab container, is running.
 
-Now, within JupyterLab, click the **Terminal** icon within the 'Launcher' tab. This opens up a command-line session within the container.
+Now, within JupyterLab, click the **Terminal** icon within the 'Launcher' tab. This opens up a command-line session within JupyterLab.
 
 Now run the following:
 
@@ -446,7 +451,7 @@ hello-from-jupyterlab-to-outputs.txt
 hello-from-outputs-to-jupyterlab.txt
 ```
 
-Hopefully, this demonstrates how the mounted directories provides a means for data, configuration files, scripts and code to be shared between the back-end on which the container is running and the environment within the container itself.
+Hopefully, this demonstrates how the mounted directories provides a means for data, configuration files, scripts and code to be shared between the back-end on which a container is running and the environment within the container itself.
 
 As a reminder, `safe_outputs/jupyter/SESSION_ID` will persist after the job which created the container ends but the `SESSION_ID` subdirectory in `scratch/jupyter` will be deleted.
 


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Deemphasised use of the term 'container' for JupyterLab and RStudio Server apps. Rewordings for clarity and consistency.

## Type of change

- [x] Formatting

## What has to be reviewed

```text
docs/safe-haven-services/open-ondemand/
getting-started.md
apps/batch-container-app.md
apps/job-composer.md
apps/jupyter-app.md
apps/rstudio-app.md
```

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
