### PR TITLE
Updated Open OnDemand docs to reflect that apps now constrain resource options

### DIFF
--- a/docs/safe-haven-services/open-ondemand/apps/batch-container-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/batch-container-app.md
@@ -19,12 +19,12 @@ Complete the following information the app form:
 * **Container/image URL in container registry**: URL specifying both the container to run and the container registry from which it is to be pulled. For example, `git.ecdf.ed.ac.uk/tre-container-execution-service/containers/epcc-ces-hello-tre:1.1`. See [Container registries](../containers.md#container-registries) for supported container registries.
 * **Container registry username**: A container registry username is required.
 * **Container registry access token**: An access token associated with the username is required. Using an access token that grants **read-only** access to the container registry is **strongly recommended**.
-* **Container runner**: Container runner - 'podman' or 'apptainer' - with which to run the container. Your selected back-end must have the container runner installed.
+* **Container runner**: Container runner - 'podman' or 'apptainer' - with which to run the container.
 * **Reuse Apptainer SIF file** (Apptainer only): When Apptainer is used, the container is pulled and an Apptainer SIF file created. The SIF file is created for the container every time. If this option is selected, then, if the SIF file can be found in your home directory, it will be reused, not recreated. SIF files are named after image names. For example, `epcc-ces-hello-tre:1.1.sif`.
 * **Container name** (Podman only): Name to be given to the container when it is run. Your job will fail if there is already a running container with that name. If omitted, then the default container name is `CONTAINER_NAME-SESSION_ID`, where `CONTAINER_NAME` is derived from the image name (if the image name is `my-container:1.0` then `CONTAINER_NAME` is `my-container`) and `SESSION_ID` is a unique session identifier for the app's job.
-* **CPUs/cores**: CPUs/cores requested for the app's job. Your chosen back-end must have the requested number of cores/CPUs available.
-* **Memory (GiB)**: Memory requested for the app's job. Your chosen back-end must have the requested memory available.
-* **Use GPU?**: Request that the container use a GPU. Your chosen back-end must have GPUs available.
+* **CPUs/cores**: CPUs/cores requested for the app's job.
+* **Memory (GiB)**: Memory requested for the app's job.
+* **Use GPU?**: Request that the container use a GPU. This option is only shown for back-ends that have a GPU.
 * **Container runner command-line arguments**: Command-line arguments to pass to the chosen container runner to control its behaviour.
 * **Environment variables**: Environment variables to be set within the container when it runs.
     * Each line should define one environment variable and value, each in the form, `ENVIRONMENT_VARIABLE=value`. For example:

--- a/docs/safe-haven-services/open-ondemand/apps/jupyter-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/jupyter-app.md
@@ -14,8 +14,8 @@ Complete the following information the app form:
 
         **National Safe Haven users**: If using a 'desktop' back-end, then you must select the 'desktop' you have been granted access to.
 
-* **CPUs/cores**: CPUs/cores requested for the app's job. Your chosen back-end must have the requested number of cores/CPUs available.
-* **Memory (GiB)**: Memory requested for the app's job. Your chosen back-end must have the requested memory available.
+* **CPUs/cores**: CPUs/cores requested for the app's job.
+* **Memory (GiB)**: Memory requested for the app's job.
 
 Click **Launch**.
 

--- a/docs/safe-haven-services/open-ondemand/apps/jupyter-os-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/jupyter-os-app.md
@@ -14,8 +14,8 @@ Complete the following information the app form:
 
         **National Safe Haven users**: If using a 'desktop' back-end, then you must select the 'desktop' you have been granted access to.
 
-* **CPUs/cores**: CPUs/cores requested for the app's job. Your chosen back-end must have the requested number of cores/CPUs available.
-* **Memory (GiB)**: Memory requested for the app's job. Your chosen back-end must have the requested memory available.
+* **CPUs/cores**: CPUs/cores requested for the app's job.
+* **Memory (GiB)**: Memory requested for the app's job.
 
 Click **Launch**.
 

--- a/docs/safe-haven-services/open-ondemand/apps/rstudio-app.md
+++ b/docs/safe-haven-services/open-ondemand/apps/rstudio-app.md
@@ -15,8 +15,8 @@ Complete the following information the app form:
         **National Safe Haven users**: If using a 'desktop' back-end, then you must select the 'desktop' you have been granted access to.
 
 * **RStudio Server password**: A password is required to secure RStudio Server. Provide a password to use.
-* **CPUs/cores**: CPUs/cores requested for the app's job. Your chosen back-end must have the requested number of cores/CPUs available.
-* **Memory (GiB)**: Memory requested for the app's job. Your chosen back-end must have the requested memory available.
+* **CPUs/cores**: CPUs/cores requested for the app's job.
+* **Memory (GiB)**: Memory requested for the app's job.
 
 Click **Launch**.
 

--- a/docs/safe-haven-services/open-ondemand/getting-started.md
+++ b/docs/safe-haven-services/open-ondemand/getting-started.md
@@ -56,15 +56,15 @@ Read the form entries in conjunction with the explanations below and make the su
     * Leave this value as-is.
 * **Container registry access token**: An access token associated with the username is required. Using an access token that grants **read-only** access to the container registry is **strongly recommended**.
     * Leave this value as-is, the access token provides read-only access to pull the container.
-* **Container runner**: Container runner - 'podman' or 'apptainer' - with which to run the container. Your selected back-end must have the container runner installed.
+* **Container runner**: Container runner - 'podman' or 'apptainer' - with which to run the container.
     * Leave this value as-is i.e., 'podman', as this is available on all back-ends.
 * **Container name** (Podman only): Name to be given to the container when it is run. Your job will fail if there is already a running container with that name. If omitted, then the default container name is `CONTAINER_NAME-SESSION_ID`, where `CONTAINER_NAME` is derived from the image name (if the image name is `my-container:1.0` then `CONTAINER_NAME` is `my-container`) and `SESSION_ID` is a unique session identifier for the app's job.
     * Leave this value as-is.
-* **CPUs/cores**: CPUs/cores requested for the app's job. To run jobs via Open OnDemand requires you to select the resources you think your job will need, including the number of CPUs/cores. Your chosen back-end must have the requested number of cores/CPUs available.
+* **CPUs/cores**: CPUs/cores requested for the app's job. To run jobs via Open OnDemand requires you to select the resources you think your job will need, including the number of CPUs/cores.
     * Leave this value as-is as the all back-ends can provide the default number of cores, and the `epcc-ces-hello-tre` container does not need any more.
-* **Memory (GiB)**: Memory requested for the app's job. Your chosen back-end must have the requested memory available.
+* **Memory (GiB)**: Memory requested for the app's job.
     * Leave this value as-is as the all back-ends can provide the default memory, and the `epcc-ces-hello-tre` container does not need any more.
-* **Use GPU?**: Request that the container use a GPU. Your chosen back-end must have GPUs available.
+* **Use GPU?**: Request that the container use a GPU. This option is only shown for back-ends that have a GPU.
     * Leave this value as-is, as the `epcc-ces-hello-tre` container does not require a GPU.
 * **Container runner command-line arguments**: Command-line arguments to pass to the chosen container runner to control its behaviour.
     * Leave this value as-is, as the container does not require any such options to be set.


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Open OnDemand apps now constrain CPU/cores, memory and GPU options based on the resources available to the back-ends as specified in their Open OnDemand cluster configuration files. There is now no need to users to independently check if a back-end has the resources available.

Rephrased relevant text in `docs/safe-haven-services/open-ondemand/`:
```text
apps/batch-container-app.md
apps/jupyter-app.md
apps/jupyter-os-app.md
apps/rstudio-app.md
getting-started.md
```

Fixes #293

## Type of change

- [x] Incorrect Documentation

## What has to be reviewed

`docs/safe-haven-services/open-ondemand/`:
```text
apps/batch-container-app.md
apps/jupyter-app.md
apps/jupyter-os-app.md
apps/rstudio-app.md
getting-started.md
```

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
