### PR TITLE
CephFS share in Notebook Service

### DIFF
--- a/docs/services/jhub/quickstart.md
+++ b/docs/services/jhub/quickstart.md
@@ -50,12 +50,11 @@ pip install <package> --user
 
 ## Data
 
-There is a project space mounted in `/project_data`. Only project accounts have permissions to view and write to their project folder in this space.
-Here you can share data with other notebook users in your project.
-Data placed in `/project_data/shared` is shared with other notebook users outside your project.
+If your project has a [CephFS](../../storage/overview.md#shared-filesystem-cephfs) allocation the project folder can be mounted to the Notebook Service. Here you can share data with other notebook users in your project, or to other EIDF services such as Virtual Desktops, GPU service, Cirrus and Cerebras.
 
-You can also share data with DSC VMs in your project.
-Please contact the helpdesk if you would like to mount this project space to one of your VMs.
+In the notebook service, users only have access to their project's own CephFS directory. The read and write permissions in the CephFS project folder are those of the user that you selected when logging in to the Notebook service.
+
+Once mounted, the project space is available at the path `/sharedfs` in your notebooks. Please contact the helpdesk if you would like your project space to be mounted.
 
 ## Limits
 

--- a/docs/storage/overview.md
+++ b/docs/storage/overview.md
@@ -60,7 +60,7 @@ See more details about [S3 at EIDF](../services/s3/index.md).
 
 ### Shared Filesystem (CephFS)
 
-Our Shared Filesystem (CephFS) provides a parallel file system accessible across EIDF services. It is directly accessible from the VM service, GPU service, Ultra2 and Cerebras.
+Our Shared Filesystem (CephFS) provides a parallel file system accessible across EIDF services. It is directly accessible from the VM service, GPU service, Notebook service, Cirrus and Cerebras.
 
 Cerebras only uses Shared Filesystem (CephFS). PIs can make it available on their VMs; see how on the documentation [mounting CephFS on VMs](../services/virtualmachines/sharedfs.md).
 


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Removes the deprecated project nfs mount from the notebook service docs and adds info about sharing CephFS to the notebook service.

Removed Ultra2 from list of services where CephFS is mounted.

## Type of change

Please delete options that are not relevant.

- [x] Incorrect Documentation
- [ ] Incomplete Documentation
- [x] Missing Documentation
- [ ] Formatting
- [ ] New Documentation

## What has to be reviewed

docs/services/jhub/quickstart.md

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
