### PR TITLE
fix location of local CA for Rocky VMs

### DIFF
--- a/docs/services/confidentialdataworkspace/router-docs.md
+++ b/docs/services/confidentialdataworkspace/router-docs.md
@@ -17,7 +17,10 @@ HTTP and HTTPS traffic from the CDW VMs is proxied through the Squid service on 
 
 ## Certificate When Using the Proxy for HTTPS Traffic
 
-For applications that require it, the self-signed certificate used by the Squid service is available on every VM at `/usr/local/share/ca-certificates/extra/squid_proxyCA.crt`.
+For applications that require it, the self-signed certificate used by the Squid service is available on every VM at:
+
+- `/usr/local/share/ca-certificates/extra/squid_proxyCA.crt` for Ubuntu
+- `/etc/pki/ca-trust/source/anchors/squid_proxyCA.crt` for Rocky
 
 ## SSH Access to the CDW Router
 


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

The local CA certificate location is different for Rocky VMs.

## Type of change

Please delete options that are not relevant.

- [x] Incorrect Documentation
- [ ] Incomplete Documentation
- [ ] Missing Documentation
- [ ] Formatting
- [ ] New Documentation

## What has to be reviewed

docs/services/confidentialdataworkspace/router-docs.md

## Checklist

- [ ] Documentation follows the project style guidelines
- [ ] Ensure Contact details contain Service Emails and Numbers
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
