### PR TITLE
Fixed docs/safe-haven-services/s3-service.md formatting and broken link

### DIFF
--- a/docs/safe-haven-services/s3-service.md
+++ b/docs/safe-haven-services/s3-service.md
@@ -119,7 +119,7 @@ You now need to configure `aws` with information about the S3 endpoint, access k
     Set the endpoint URL. For example:
 
     ```console
-    aws configure set endpoint-url http://nsh-fs02:7070
+    aws configure set endpoint_url https://s3.eidf.ac.uk
     ```
 
     For more information, see the AWS documentation about [configuration variables](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html).

--- a/docs/safe-haven-services/s3-service.md
+++ b/docs/safe-haven-services/s3-service.md
@@ -4,7 +4,7 @@ Some *Safe Havens* provide access to large collections of files via a S3 service
 If this applies to your project, your Research Coordinator will provide you with an access key.
 This document will guide you through getting access to the data from a terminal as well as programmatically via R and Python.
 
-Unlike the [EIDF S3 service](../services/s3/) this is not a storage solution for users wanting to create their own files;
+Unlike the [EIDF S3 service](../services/s3/index.md) this is not a storage solution for users wanting to create their own files;
 all files are read-only.
 
 !!! Note

--- a/docs/safe-haven-services/s3-service.md
+++ b/docs/safe-haven-services/s3-service.md
@@ -7,12 +7,14 @@ This document will guide you through getting access to the data from a terminal 
 Unlike the [EIDF S3 service](../services/s3/) this is not a storage solution for users wanting to create their own files;
 all files are read-only.
 
-> [!NOTE]
-> If you need to modify the files you will need to download them to your project space, but such space is necessarily limited so only download what you need and delete it as soon as no longer needed. Below you will see how to process data without keeping a local copy.
+!!! Note
+
+    If you need to modify the files you will need to download them to your project space, but such space is necessarily limited so only download what you need and delete it as soon as no longer needed. Below you will see how to process data without keeping a local copy.
 
 ## Access arrangements
 
 To access files you need to know:
+
 * An "endpoint URL" (for the NSH this is `http://nsh-fs02:7070`)
 * The "Region" of the service (for the NSH this is `us-east-1`)
 * A "bucket" name (similar to a folder name)
@@ -26,6 +28,7 @@ All file accesses are logged.
 ## How to use the service
 
 The access keys and other details can be configured in several ways:
+
 * directly coding them into your scripts
 * set in environment variables
 * saved in a configuration file
@@ -40,11 +43,11 @@ Many S3 tools will read environment variables so this can be a convenient way to
 | Access key     | AWS_ACCESS_KEY_ID     | as provided by RC    |
 | Secret key     | AWS_SECRET_ACCESS_KEY | as provided by RC    |
 
+!!! Note
 
-> [!NOTE]
-> If your account has access to R/Python packages via a web proxy then you
-> need to temporarily disable it whilst using the S3 service. This is shown
-> in the examples below.
+    If your account has access to R/Python packages via a web proxy then you
+    need to temporarily disable it whilst using the S3 service. This is shown
+    in the examples below.
 
 ## Performance tips
 
@@ -54,7 +57,8 @@ Many S3 tools will read environment variables so this can be a convenient way to
 ## Example using the command-line in the Terminal window
 
 First, install the `aws` command:
-```
+
+```console
 pip install awscli
 ```
 
@@ -63,15 +67,17 @@ If you get `command not found` then run it as `~/.local/bin/aws`
 and consider adding `~/.local/bin` to your `PATH` environment variable.
 
 Make sure your proxy configuration is not applied to the aws command:
-```
+
+```console
 export NO_PROXY=nsh-fs02
 export no_proxy=nsh-fs02
 ```
 
 Now you can list the contents of a bucket and download a file, for example:
-```
-aws s3  ls  s3://bucket_name
-aws s3  cp  s3://bucket_name/filename.dcm  copy_of_filename.dcm
+
+```console
+aws s3 ls s3://bucket_name
+aws s3 cp s3://bucket_name/filename.dcm copy_of_filename.dcm
 ```
 
 At this point it will complain that it can't locate your credentials.
@@ -79,36 +85,42 @@ There are two ways to supply the information: in environment variables, or
 in a configuration file.
 
 Environment variables can be set:
-```
+
+```console
 export AWS_DEFAULT_REGION=us-east-1
 export AWS_ENDPOINT_URL=http://nsh-fs02:7070
 export AWS_S3_ENDPOINT=http://nsh-fs02:7070
 export AWS_ACCESS_KEY_ID=put_your_key_here
 export AWS_SECRET_ACCESS_KEY=put_your_secret_here
 ```
-(See the AWS documentation about [env vars](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html)
+
+(See the AWS documentation about [environment variables](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html)
 and [credentials](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#credentials).)
 
 Credentials can be stored in a configuration file
-manually (see the [AWS docs](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html)),
-or with a command (see the [AWS docs](https://docs.aws.amazon.com/cli/latest/reference/configure/set.html)):
-```
+manually (see the AWS documentation about [credential files](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html)),
+or via the `aws configure set` command (see the AWS documentation about [aws configure set](https://docs.aws.amazon.com/cli/latest/reference/configure/set.html)):
+
+```console
 aws configure
 ```
+
 and providing the access key, secret key and region (ignore the output format).
+
 You should also set the endpoint URL, e.g.
-```
+
+```console
 aws configure set --endpoint-url http://nsh-fs02:7070
 ```
 
 The above commands for copying files can now be used.
-
 
 ## Example using Python
 
 ### Setup
 
 First, install the `boto3` package:
+
 ```console
 python3 -m virtualenv venv
 source venv/bin/activate
@@ -141,6 +153,7 @@ pip install pydicom
 ```
 
 This will load the data into a pydicom dataset without actually storing a file on disk:
+
 ```py
 import io
 import os
@@ -166,14 +179,17 @@ There are three different packages for R, you can install `s3` or `aws.s3` or `p
 
 You should have the environment variables set, either in your terminal (see above), or in your `.Renviron` file, or explicitly in your R script using `Sys.setenv`.
 
-> [!NOTE]
-> For the endpoint, `aws.s3` uses a different name `AWS_S3_ENDPOINT`.
+!!! Note
 
-> [!NOTE]
-> Only *after* you have installed packages with `install.packages()` you should use `Sys.setenv( http_proxy="" )`
+    For the endpoint, `aws.s3` uses a different name `AWS_S3_ENDPOINT`.
+
+!!! Note
+
+    Only *after* you have installed packages with `install.packages()` you should use `Sys.setenv( http_proxy="" )`
 
 An example R script to download a file from S3:
-```
+
+```r
 library(aws.s3)
 my_bucket <- "dummydata"
 my_access_key <- "dummydata"
@@ -189,17 +205,19 @@ Sys.setenv( http_proxy="" )
 save_object( my_object_path, file = "downloaded.dcm", bucket = my_bucket, base_url=my_endpoint_host, region="", use_https=FALSE, key = my_access_key, secret = my_secret_key )
 ```
 
-> [!NOTE]
-> You need to have the region set in the environment variable and pass `region=""` to the functions,
-> otherwise you get a `cannot resolve host` error.
-> The `base_url` is just the host and port, no `http://` prefix, and `use_https` is false.
+!!! Note
+
+    You need to have the region set in the environment variable and pass `region=""` to the functions, otherwise you get a `cannot resolve host` error.
+
+    The `base_url` is just the host and port, no `http://` prefix, and `use_https` is false.
 
 ### Advanced R usage
 
 To consume data via a temporary file see the function [s3read_using](https://rdrr.io/cran/aws.s3/man/s3read_using.html).
 
 To consume data without using any files, use [rawConnection](https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/rawConnection) with the data from [get_object](https://www.rdocumentation.org/packages/aws.s3/versions/0.3.21/topics/get_object).
-```
+
+```r
 obj = get_object( my_object_path, bucket = my_bucket, base_url=my_endpoint_host, region="", use_https=FALSE, key = my_access_key, secret = my_secret_key )
 con = rawConnection(obj, "r")
 dicom_processing_function(con)
@@ -213,33 +231,47 @@ This example uses a customised program that can view and download DICOM files fr
 It is not installed in the Safe Haven but you can import it as a container image.
 
 You will need these provided by your Research Coordinator:
+
 * a CSV file which contains a list of StudyInstanceUID and SeriesInstanceUID
 * a github token to download the container image
 
 In a terminal window run this command to obtain the container image, replacing TOKEN with the github token you were given:
-```
+
+```console
 ces-pull podman howff TOKEN ghcr.io/howff/dcmaudit:cpu
 ```
-You will see the container image listed when you run:
-```
-podman images
 
+You will see the container image listed when you run:
+
+```console
+podman images
+```
+
+For example:
+
+```console
 REPOSITORY                TAG    IMAGE ID      CREATED       SIZE
 ghcr.io/howff/dcmaudit    cpu    4f994194efa8  11 days ago   2.67 GB
 ```
+
 Now you will need a 's3' directory in your home directory so create that first, for example:
-```
+
+```console
 mkdir ~/s3
 ```
 
 To run the container use:
-```
+
+```console
 ces-pm-run --opt-file <(echo -v $HOME/.dcmaudit:/root/.dcmaudit -v $HOME/s3:/root/s3 --http-proxy=false) ghcr.io/howff/dcmaudit:cpu
 ```
+
 That is difficult to type every time you need it, so you can create a script:
-```
+
+```console
 echo '#!/bin/bash' > ~/dcmaudit.sh
 echo 'ces-pm-run --opt-file <(echo -v $HOME/.dcmaudit:/root/.dcmaudit -v $HOME/s3:/root/s3 --http-proxy=false) ghcr.io/howff/dcmaudit:cpu' >> ~/dcmaudit.sh
 chmod +x ~/dcmaudit.sh
 ```
+
 Now to run the viewer you can run `~/dcmaudit.sh` from a terminal window or double-click on it in a file browser.

--- a/docs/safe-haven-services/s3-service.md
+++ b/docs/safe-haven-services/s3-service.md
@@ -1,13 +1,12 @@
 # S3 Service
 
-Some *Safe Havens* provide access to large collections of files via a S3 service.
-If this applies to your project, your Research Coordinator will provide you with an access key.
-This document will guide you through getting access to the data from a terminal as well as programmatically via R and Python.
+Some *Safe Havens* may provide you with access to large collections of files via an S3 service. If this applies to your project, your Research Coordinator will provide you with the information you need to connect to the S3 service. This documentation guides you through how to get access to the data from a terminal as well as programmatically via Python and R.
 
-Unlike the [EIDF S3 service](../services/s3/index.md) this is not a storage solution for users wanting to create their own files;
-all files are read-only.
+!!! Important
 
-!!! Note
+    Unlike the [EIDF S3 service](../services/s3/index.md), Safe Haven S3 services are not a storage solution for users wanting to create or update their own files; all files are **read-only**.
+
+!!! Important
 
     If you need to modify the files you will need to download them to your project space, but such space is necessarily limited so only download what you need and delete it as soon as no longer needed. Below you will see how to process data without keeping a local copy.
 
@@ -15,111 +14,139 @@ all files are read-only.
 
 To access files you need to know:
 
-* An "endpoint URL" (for the NSH this is `http://nsh-fs02:7070`)
-* The "Region" of the service (for the NSH this is `us-east-1`)
+* An "endpoint URL" (e.g., for the National Safe Haven, this is `http://nsh-fs02:7070`)
+* The "Region" of the service (e.g., for the National Safe Haven this is `us-east-1`)
 * A "bucket" name (similar to a folder name)
 * An "access key" (similar to a username)
 * A "private key" (similar to a password)
 
-All of the above will be supplied to you by your Research Coordinator.
-S3 access and secret key details are confidential and must never be shared or allowed to be seen by others.
+All of the above will be supplied to you by your Research Coordinator. S3 access and secret key details are confidential and must never be shared or allowed to be seen by others.
+
 All file accesses are logged.
 
-## How to use the service
+## How to configure access to the service
 
-The access keys and other details can be configured in several ways:
+The access keys and other details can be configured in several ways. For example:
 
 * directly coding them into your scripts
 * set in environment variables
 * saved in a configuration file
 
-Many S3 tools will read environment variables so this can be a convenient way to provide the details.
+Many S3 tools will read environment variables so these can be a convenient way to provide the details. A selection of environment variables is as follows:
 
-|Setting         |Environment variable   |Value                 |
-|----------------|-----------------------|----------------------|
-| Region         | AWS_DEFAULT_REGION    | us-east-1            |
-| Server address | AWS_ENDPOINT_URL      | http://nsh-fs02:7070 |
-| (or Endpoint)  | AWS_S3_ENDPOINT       | same (for R aws.s3)  |
-| Access key     | AWS_ACCESS_KEY_ID     | as provided by RC    |
-| Secret key     | AWS_SECRET_ACCESS_KEY | as provided by RC    |
+| Setting        | Environment variable  | Value                               |
+|----------------|-----------------------|-------------------------------------|
+| Region         | AWS_DEFAULT_REGION    | us-east-1                           |
+| Server address | AWS_ENDPOINT_URL      | http://nsh-fs02:7070                |
+| (or Endpoint)  | AWS_S3_ENDPOINT       | same (for R aws.s3)                 |
+| Access key     | AWS_ACCESS_KEY_ID     | as provided by Research Coordinator |
+| Secret key     | AWS_SECRET_ACCESS_KEY | as provided by Research Coordinator |
 
-!!! Note
+!!! Important
 
-    If your account has access to R/Python packages via a web proxy then you
-    need to temporarily disable it whilst using the S3 service. This is shown
-    in the examples below.
+    If your account has access to Python/R packages via a web proxy, then you need to temporarily disable it whilst using the S3 service. This is shown in the examples below.
 
 ## Performance tips
 
-* consume the file directly in memory if possible. Saving to disk is not recommended; it wastes disk space and will take 3 times longer to do your processing. See the example code below.
-* If you need to save into a file temporarily (e.g. whilst converting to NIFTI) then save into a RAM disk in `/run/user/$(id -u)/` but delete it straight after use to recover the memory.
+Consume any file directly in memory if possible. Saving to disk is not recommended; it wastes disk space and it will take 3 times longer to do your processing.
+
+If you need to save into a file temporarily (e.g., whilst converting to NIFTI), then save the file into a RAM disk in `/run/user/$(id -u)/`, but delete it straight after use to recover the memory.
 
 ## Example using the command-line in the Terminal window
 
-First, install the `aws` command:
+First, install the AWS CLI tool, `aws`, via the [awscli](https://pypi.org/project/awscli/) Python package:
 
 ```console
 pip install awscli
 ```
 
-Check this is installed by running `aws`. This should show the command's help documentation.
-If you get `command not found` then run it as `~/.local/bin/aws`
-and consider adding `~/.local/bin` to your `PATH` environment variable.
+Check that `aws` is now installed:
 
-Make sure your proxy configuration is not applied to the aws command:
+```console
+aws --version
+```
+
+The `aws` version should be displayed.
+
+If you get `command not found`, then run `aws` via `~/.local/bin/aws`. Alternatively, add `~/.local/bin` to your `PATH` environment variable:
+
+```console
+export PATH="~/.local/bin:$PATH"
+```
+
+Now, define environment variables to make sure that your web proxy configuration is not applied to the `aws` command, and that requests to the S3 service go straight to the service. For example:
 
 ```console
 export NO_PROXY=nsh-fs02
 export no_proxy=nsh-fs02
 ```
 
-Now you can list the contents of a bucket and download a file, for example:
+You now need to configure `aws` with information about the S3 endpoint, access key and secret. There are three ways that this can be done:
+
+1. Set environment variables. For example:
+
+    ```console
+    export AWS_DEFAULT_REGION=us-east-1
+    export AWS_ENDPOINT_URL=http://nsh-fs02:7070
+    export AWS_S3_ENDPOINT=http://nsh-fs02:7070
+    export AWS_ACCESS_KEY_ID=put_your_key_here
+    export AWS_SECRET_ACCESS_KEY=put_your_secret_here
+    ```
+
+    For more information, see the AWS documentation about [environment variables](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html).
+
+    !!! Note
+
+        Both `AWS_ENDPOINT_URL` and `AWS_S3_ENDPOINT` are defined as the former is a standard Amazon environment variable, but the latter is often used by S3-specific tools.
+
+1. Set `aws` configuration parameters:
+
+    First, interactively provide the access key, secret and region:
+
+    ```console
+    aws configure
+    ```
+
+    You will be prompted for each in turn. You will also be prompted for an output format, for which you can press return, leaving the value undefined. For example:
+
+    ```console
+    AWS Access Key ID [None]: put_your_key_here
+    AWS Secret Access Key [None]: put_your_secret_here
+    Default region name [None]: us-east-1
+    Default output format [None]:
+    ```
+
+    Set the endpoint URL. For example:
+
+    ```console
+    aws configure set endpoint-url http://nsh-fs02:7070
+    ```
+
+    For more information, see the AWS documentation about [configuration variables](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html).
+
+    !!! Note
+
+        `aws configure` writes credentials values to `~/aws/credentials` and endpoint and region information to `~/aws/config`.
+
+1. Manually create AWS credentials and configuration files with these settings. See the AWS documentation about [configuration and credential files](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html).
+
+Now, you can list the contents of a bucket. For example:
 
 ```console
 aws s3 ls s3://bucket_name
+```
+
+You can download a file. For example:
+
+```console
 aws s3 cp s3://bucket_name/filename.dcm copy_of_filename.dcm
 ```
 
-At this point it will complain that it can't locate your credentials.
-There are two ways to supply the information: in environment variables, or
-in a configuration file.
-
-Environment variables can be set:
-
-```console
-export AWS_DEFAULT_REGION=us-east-1
-export AWS_ENDPOINT_URL=http://nsh-fs02:7070
-export AWS_S3_ENDPOINT=http://nsh-fs02:7070
-export AWS_ACCESS_KEY_ID=put_your_key_here
-export AWS_SECRET_ACCESS_KEY=put_your_secret_here
-```
-
-(See the AWS documentation about [environment variables](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html)
-and [credentials](https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#credentials).)
-
-Credentials can be stored in a configuration file
-manually (see the AWS documentation about [credential files](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html)),
-or via the `aws configure set` command (see the AWS documentation about [aws configure set](https://docs.aws.amazon.com/cli/latest/reference/configure/set.html)):
-
-```console
-aws configure
-```
-
-and providing the access key, secret key and region (ignore the output format).
-
-You should also set the endpoint URL, e.g.
-
-```console
-aws configure set --endpoint-url http://nsh-fs02:7070
-```
-
-The above commands for copying files can now be used.
-
 ## Example using Python
 
-### Setup
+### Setup Python
 
-First, install the `boto3` package:
+Create a virtual environment and install the Amazon Web Services Software Development Kit for Python, [boto3](https://pypi.org/project/boto3/), into it:
 
 ```console
 python3 -m virtualenv venv
@@ -127,32 +154,37 @@ source venv/bin/activate
 pip install boto3
 ```
 
-Credentials can be passed in as parameters to the functions, as shown below,
-or as environment variables. The latter can be set externally (see the examples
-above) or in your script using `os.environ`.
+Credentials can be passed in as parameters to the functions, as shown below, or as environment variables, as described above. Alternatively, you can set environment variables from within Python using `os.environ`.
 
 ### Download an object using boto3
+
+The following Python code downloads an object from a bucket:
 
 ```py
 import os
 import boto3
 os.environ["http_proxy"] = ""
-resource = boto3.resource("s3",
+resource = boto3.resource(
+    "s3",
     region_name = "us-east-1",
     endpoint_url = "http://nsh-fs02:7070",
-    aws_access_key_id = "dummydata",
+    aws_access_key_id = "put_your_key_here",
     aws_secret_access_key = "put_your_secret_here")
-bucket = resource.Bucket("dummydata")
-bucket.download_file("326834963428524640226726425259803542053/249177910747091225438117569123869339900/MR.304084489533501143843524990882920225135-an.dcm", "downloaded.dcm")
+bucket = resource.Bucket("bucket_name")
+bucket.download_file(
+    "326834963428524640226726425259803542053/249177910747091225438117569123869339900/MR.304084489533501143843524990882920225135-an.dcm",
+    "downloaded.dcm")
 ```
 
-### Load object into pydicom dataset
+### Download an object into a pydicom dataset
+
+Install the [pydicom](https://pypi.org/project/pydicom/) package:
 
 ```console
 pip install pydicom
 ```
 
-This will load the data into a pydicom dataset without actually storing a file on disk:
+The following Python code downloads an object from a bucket into a pydicom dataset without actually storing a corresponding file on disk:
 
 ```py
 import io
@@ -160,40 +192,52 @@ import os
 import boto3
 import pydicom
 os.environ["http_proxy"] = ""
-resource = boto3.resource("s3",
+resource = boto3.resource(
+    "s3",
     region_name = "us-east-1",
     endpoint_url = "http://nsh-fs02:7070",
-    aws_access_key_id = "dummydata",
+    aws_access_key_id = "put_your_key_here",
     aws_secret_access_key = "put_your_secret_here")
-bucket = resource.Bucket("dummydata")
+bucket = resource.Bucket("bucket_name")
 obj = bucket.Object("326834963428524640226726425259803542053/249177910747091225438117569123869339900/MR.304084489533501143843524990882920225135-an.dcm")
 dcm_bytes = io.BytesIO(obj.get()["Body"].read())
 ds = pydicom.dcmread(dcm_bytes)
 print(ds["StudyInstanceUID"])
+```
+
+An example output from the `print` statement might be:
+
+```text
 # (0020,000D) Study Instance UID                  UI: 1.2.840.113619.2.411.3.4077533701.216.1476084945.95
 ```
 
 ## Example using R
 
-There are three different packages for R, you can install `s3` or `aws.s3` or `paws`, but `aws.s3` is recommended and documented here.
+### Setup R
 
-You should have the environment variables set, either in your terminal (see above), or in your `.Renviron` file, or explicitly in your R script using `Sys.setenv`.
+There are three different packages for R that you could install:
 
-!!! Note
+* [aws.s3](https://cran.r-project.org/web/packages/aws.s3/)
+* [s3](https://cran.r-project.org/web/packages/s3/)
+* [paws](https://cran.r-project.org/web/packages/paws/)
 
-    For the endpoint, `aws.s3` uses a different name `AWS_S3_ENDPOINT`.
+`aws.s3` is recommended and documented here.
 
-!!! Note
+Credentials can be passed in as environment variables, as described above. Alternatively, you can set environment variables within your `.Renviron` file or from within R using `Sys.setenv`.
 
-    Only *after* you have installed packages with `install.packages()` you should use `Sys.setenv( http_proxy="" )`
+!!! Important
 
-An example R script to download a file from S3:
+    For the endpoint, `aws.s3` uses environment variable `AWS_S3_ENDPOINT`, not `AWS_ENDPOINT_URL`.
+
+### Download an object using aws.cli
+
+The following R code downloads an object from a bucket:
 
 ```r
 library(aws.s3)
-my_bucket <- "dummydata"
-my_access_key <- "dummydata"
-my_secret_key <- "abigsecretkey"
+my_bucket <- "bucket_name"
+my_access_key <- "put_your_key_here"
+my_secret_key <- "put_your_secret_here"
 my_region <- "us-east-1"
 my_endpoint <- "http://nsh-fs02:7070"
 my_endpoint_host <- "nsh-fs02:7070"
@@ -202,76 +246,102 @@ Sys.setenv( AWS_ENDPOINT_URL="http://nsh-fs02:7070" )
 Sys.setenv( AWS_S3_ENDPOINT="http://nsh-fs02:7070" )
 Sys.setenv( AWS_DEFAULT_REGION="us-east-1" )
 Sys.setenv( http_proxy="" )
-save_object( my_object_path, file = "downloaded.dcm", bucket = my_bucket, base_url=my_endpoint_host, region="", use_https=FALSE, key = my_access_key, secret = my_secret_key )
+save_object( my_object_path,
+             file = "downloaded.dcm",
+             bucket = my_bucket,
+             base_url = my_endpoint_host,
+             region = "",
+             use_https = FALSE,
+             key = my_access_key,
+             secret = my_secret_key )
 ```
 
-!!! Note
+!!! Important
 
-    You need to have the region set in the environment variable and pass `region=""` to the functions, otherwise you get a `cannot resolve host` error.
+    `install.packages()` must be called **before** `Sys.setenv( http_proxy="" )`, so that any packages are downloaded via the web proxy otherwise R won't be able to access the packages.
 
-    The `base_url` is just the host and port, no `http://` prefix, and `use_https` is false.
+    You need to have the region set in the environment variable `AWS_DEFAULT_REGION` and pass `region=""` to `save_object`, otherwise you will get a `cannot resolve host` error.
 
-### Advanced R usage
+    The `base_url` argument to `save_object` is the host and port only with no `http://` prefix.
 
-To consume data via a temporary file see the function [s3read_using](https://rdrr.io/cran/aws.s3/man/s3read_using.html).
+    `use_https` must be `FALSE`.
 
-To consume data without using any files, use [rawConnection](https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/rawConnection) with the data from [get_object](https://www.rdocumentation.org/packages/aws.s3/versions/0.3.21/topics/get_object).
+### Download an object into a DICOM dataset
+
+To consume data via a temporary file, see the `aws.s3` function [s3read_using](https://rdrr.io/cran/aws.s3/man/s3read_using.html).
+
+To consume data without using any files, use the R [rawConnection](https://www.rdocumentation.org/packages/base/versions/3.6.2/topics/rawConnection) object to stream data from [get_object](https://rdrr.io/cran/aws.s3/man/get_object.html) function, then stream this in turn into a function that can create a DICOM object (represented in the following by `dicom_processing_function`). For example:
 
 ```r
-obj = get_object( my_object_path, bucket = my_bucket, base_url=my_endpoint_host, region="", use_https=FALSE, key = my_access_key, secret = my_secret_key )
+obj = get_object( my_object_path,
+                  bucket = my_bucket,
+                  base_url = my_endpoint_host,
+                  region = "",
+                  use_https = FALSE,
+                  key = my_access_key,
+                  secret = my_secret_key )
 con = rawConnection(obj, "r")
 dicom_processing_function(con)
 ```
 
-Examples of such functions are `oro.dicom::parseDICOMHeader()` and `espadon::dicom.browser()`
+Examples of such functions are [oro.dicom](https://cran.r-project.org/web/packages/oro.dicom/)'s `parseDICOMHeader()` or [espadon::dicom.browser()](https://rdrr.io/cran/espadon/man/dicom.browser.html).
 
-## Example GUI to view DICOM files
+## Example using a GUI program to view DICOM files
 
-This example uses a customised program that can view and download DICOM files from the S3 service.
-It is not installed in the Safe Haven but you can import it as a container image.
+This example uses a customised program that can view and download DICOM files from the S3 service. It is not installed in any Safe Haven but you can import it as a container image.
 
-You will need these provided by your Research Coordinator:
+You will need the following to be provided by your Research Coordinator:
 
-* a CSV file which contains a list of StudyInstanceUID and SeriesInstanceUID
-* a github token to download the container image
+* A CSV file within a bucket which contains a list of `StudyInstanceUID` and `SeriesInstanceUID`.
+* A GitHub token to download the container image, ghcr.io/howff/dcmaudit:cpu.
 
-In a terminal window run this command to obtain the container image, replacing TOKEN with the github token you were given:
+In a terminal window, run the following command to obtain the container image, replacing `TOKEN` with the GitHub token you were given:
 
 ```console
 ces-pull podman howff TOKEN ghcr.io/howff/dcmaudit:cpu
 ```
 
-You will see the container image listed when you run:
+List the Podman container images:
 
 ```console
 podman images
 ```
 
-For example:
+You will see the container image listed. For example:
 
 ```console
 REPOSITORY                TAG    IMAGE ID      CREATED       SIZE
 ghcr.io/howff/dcmaudit    cpu    4f994194efa8  11 days ago   2.67 GB
 ```
 
-Now you will need a 's3' directory in your home directory so create that first, for example:
+Now, create an `s3` directory in your home directory:
 
 ```console
 mkdir ~/s3
 ```
 
-To run the container use:
+Now you can run the container:
 
 ```console
 ces-pm-run --opt-file <(echo -v $HOME/.dcmaudit:/root/.dcmaudit -v $HOME/s3:/root/s3 --http-proxy=false) ghcr.io/howff/dcmaudit:cpu
 ```
 
-That is difficult to type every time you need it, so you can create a script:
+The GUI viewer should appear.
 
-```console
-echo '#!/bin/bash' > ~/dcmaudit.sh
-echo 'ces-pm-run --opt-file <(echo -v $HOME/.dcmaudit:/root/.dcmaudit -v $HOME/s3:/root/s3 --http-proxy=false) ghcr.io/howff/dcmaudit:cpu' >> ~/dcmaudit.sh
-chmod +x ~/dcmaudit.sh
-```
+!!! Tip
 
-Now to run the viewer you can run `~/dcmaudit.sh` from a terminal window or double-click on it in a file browser.
+    As running this command can be difficult to type every time you need it, you can create a script:
+
+    ```console
+    echo '#!/bin/bash' > ~/dcmaudit.sh
+    echo 'ces-pm-run --opt-file <(echo -v $HOME/.dcmaudit:/root/.dcmaudit -v $HOME/s3:/root/s3 --http-proxy=false) ghcr.io/howff/dcmaudit:cpu' >> ~/dcmaudit.sh
+    chmod +x ~/dcmaudit.sh
+    ```
+
+    Now, you can run the container via:
+
+    ```console
+    `~/dcmaudit.sh
+    ```
+
+    Alternatively, you can double-click `dcmaudit.sh` from within a file browser.

--- a/docs/services/cirrus/index.md
+++ b/docs/services/cirrus/index.md
@@ -1,6 +1,6 @@
 # Overview
 
-The Cirrus service provides access to CPU-based high-performance computing resources. As well as being part of the 
+The Cirrus service provides access to CPU-based high-performance computing resources. As well as being part of the
 EIDF, Cirrus is one of the UKRI National Compute Resources (NCRs).
 
 Cirrus is a HPE EX4000 supercomputing system which has a total of 256 compute nodes. Each compute node has 288 cores (dual AMD EPYC 9825 144-core 2.2 GHz processors) giving a total of 73,228 cores. 192 are standard memory compute nodes with 768 GB DDR5 RAM and 64 are high memory compute nodes with 1536 GB DDR5 RAM. Compute nodes are connected together by a HPE Slingshot 11 interconnect.


### PR DESCRIPTION
# EIDF Documentation Pull Request

## Description

Fixed formatting to address 'pre-commit' check failures:

MD012 Multiple consecutive blank lines
MD028 Blank line inside blockquote
MD040 Fenced code blocks should have a language specified
MD031 Fenced code blocks should be surrounded by blank lines
MD032 Lists should be surrounded by blank lines

Replaced `[NOTE]` blocks with `!!! Note` blocks

Fixed broken link to `docs/services/s3/` to be to `docs/services/s3/index.md`.

Myriad tweaks for readability and consistency.

## Type of change

Please delete options that are not relevant.

- [x] Incorrect Documentation
- [x] Formatting

## What has to be reviewed

`docs/safe-haven-services/s3-service.md`

## Checklist

- [x] Documentation follows the project style guidelines
- [x] Self-review of documentation using mkdocs on local system
- [x] Spellcheck has been performed
- [x] Pre-commit has been run and passed
